### PR TITLE
Context tweaks

### DIFF
--- a/jingle/src/main.rs
+++ b/jingle/src/main.rs
@@ -117,9 +117,7 @@ fn get_instructions(
     let img = decode(hex_bytes).unwrap();
     let max_len = img.len();
     let mut offset = 0;
-    let mut sleigh = sleigh_build
-        .build(&architecture)
-        .unwrap();
+    let mut sleigh = sleigh_build.build(&architecture).unwrap();
     sleigh.set_image(img).unwrap();
     let mut instrs = vec![];
     while offset < max_len {

--- a/jingle/src/main.rs
+++ b/jingle/src/main.rs
@@ -117,17 +117,17 @@ fn get_instructions(
     let img = decode(hex_bytes).unwrap();
     let max_len = img.len();
     let mut offset = 0;
-    let sleigh = sleigh_build
-        .set_image(Image::from(img))
+    let mut sleigh = sleigh_build
         .build(&architecture)
         .unwrap();
+    sleigh.set_image(img).unwrap();
     let mut instrs = vec![];
     while offset < max_len {
-        for instruction in sleigh.read(offset as u64, 1) {
+        for instruction in sleigh.instruction_at(offset as u64) {
             offset += instruction.length;
             instrs.push(instruction);
         }
-        if sleigh.read(offset as u64, 1).next().is_none() {
+        if sleigh.instruction_at(offset as u64).is_none() {
             break;
         }
     }

--- a/jingle/src/translator.rs
+++ b/jingle/src/translator.rs
@@ -1,5 +1,4 @@
 use crate::error::JingleError;
-use jingle_sleigh::context::SleighContext;
 use jingle_sleigh::{Instruction, RegisterManager, SpaceInfo, VarNode};
 
 use crate::modeling::ModeledInstruction;

--- a/jingle/src/translator.rs
+++ b/jingle/src/translator.rs
@@ -3,10 +3,10 @@ use jingle_sleigh::context::SleighContext;
 use jingle_sleigh::{Instruction, RegisterManager, SpaceInfo, VarNode};
 
 use crate::modeling::ModeledInstruction;
+use jingle_sleigh::context::loaded::LoadedSleighContext;
 use jingle_sleigh::JingleSleighError::InstructionDecode;
 use jingle_sleigh::SpaceManager;
 use z3::Context;
-use jingle_sleigh::context::loaded::LoadedSleighContext;
 
 /// This type wraps z3 and a sleigh context and allows for both modeling instructions that
 /// sleigh context has already produced, or reading new instructions directly out of sleigh and

--- a/jingle/src/translator.rs
+++ b/jingle/src/translator.rs
@@ -31,8 +31,7 @@ impl<'ctx> SleighTranslator<'ctx> {
     ) -> Result<ModeledInstruction<'ctx>, JingleError> {
         let op = self
             .sleigh
-            .read(offset, 1)
-            .next()
+            .instruction_at(offset)
             .ok_or(InstructionDecode)?;
         self.model_instruction(op)
     }

--- a/jingle/src/translator.rs
+++ b/jingle/src/translator.rs
@@ -6,6 +6,7 @@ use crate::modeling::ModeledInstruction;
 use jingle_sleigh::JingleSleighError::InstructionDecode;
 use jingle_sleigh::SpaceManager;
 use z3::Context;
+use jingle_sleigh::context::loaded::LoadedSleighContext;
 
 /// This type wraps z3 and a sleigh context and allows for both modeling instructions that
 /// sleigh context has already produced, or reading new instructions directly out of sleigh and
@@ -13,12 +14,12 @@ use z3::Context;
 #[derive(Debug, Clone)]
 pub struct SleighTranslator<'ctx> {
     z3_ctx: &'ctx Context,
-    sleigh: &'ctx SleighContext,
+    sleigh: &'ctx LoadedSleighContext,
 }
 
 impl<'ctx> SleighTranslator<'ctx> {
     /// Make a new sleigh translator
-    pub fn new(sleigh: &'ctx SleighContext, z3_ctx: &'ctx Context) -> Self {
+    pub fn new(sleigh: &'ctx LoadedSleighContext, z3_ctx: &'ctx Context) -> Self {
         Self { z3_ctx, sleigh }
     }
 

--- a/jingle_sleigh/.gitignore
+++ b/jingle_sleigh/.gitignore
@@ -1,3 +1,4 @@
 cmake-build-debug
 .idea
+.cache
 build

--- a/jingle_sleigh/CMakeLists.txt
+++ b/jingle_sleigh/CMakeLists.txt
@@ -33,7 +33,9 @@ add_library(jingle_sleigh_cpp
         src/ffi/cpp/context.h
         src/ffi/cpp/sleigh_image.cpp
         src/ffi/cpp/sleigh_image.h
-        src/ffi/cpp/exception.h)
+        src/ffi/cpp/exception.h
+        src/ffi/cpp/varnode_translation.cpp
+        src/ffi/cpp/varnode_translation.h)
 
 add_executable(sleigh_compile
         src/ffi/cpp/sleigh/address.cc

--- a/jingle_sleigh/CMakeLists.txt
+++ b/jingle_sleigh/CMakeLists.txt
@@ -30,7 +30,10 @@ add_library(jingle_sleigh_cpp
         src/ffi/cpp/compile.cpp
         src/ffi/cpp/addrspace_handle.cpp
         src/ffi/cpp/addrspace_manager_handle.cpp
-        src/ffi/cpp/context.h)
+        src/ffi/cpp/context.h
+        src/ffi/cpp/image_context.cpp
+        src/ffi/cpp/image_context.h
+        src/ffi/cpp/exception.h)
 
 add_executable(sleigh_compile
         src/ffi/cpp/sleigh/address.cc

--- a/jingle_sleigh/CMakeLists.txt
+++ b/jingle_sleigh/CMakeLists.txt
@@ -31,8 +31,8 @@ add_library(jingle_sleigh_cpp
         src/ffi/cpp/addrspace_handle.cpp
         src/ffi/cpp/addrspace_manager_handle.cpp
         src/ffi/cpp/context.h
-        src/ffi/cpp/image_context.cpp
-        src/ffi/cpp/image_context.h
+        src/ffi/cpp/sleigh_image.cpp
+        src/ffi/cpp/sleigh_image.h
         src/ffi/cpp/exception.h)
 
 add_executable(sleigh_compile

--- a/jingle_sleigh/build.rs
+++ b/jingle_sleigh/build.rs
@@ -20,6 +20,7 @@ fn main() {
     let rust_sources = vec![
         "src/ffi/addrspace.rs",
         "src/ffi/context_ffi.rs",
+        "src/ffi/sleigh_image.rs",
         "src/ffi/instruction.rs",
         "src/ffi/opcode.rs",
         "src/ffi/image.rs",
@@ -49,6 +50,8 @@ fn main() {
         "src/ffi/cpp/sleigh/slghscan.cc",
         "src/ffi/cpp/sleigh/slghparse.cc",
         "src/ffi/cpp/context.cpp",
+        "src/ffi/cpp/dummy_load_image.cpp",
+        "src/ffi/cpp/sleigh_image.cpp",
         "src/ffi/cpp/addrspace_handle.cpp",
         "src/ffi/cpp/addrspace_manager_handle.cpp",
     ];

--- a/jingle_sleigh/build.rs
+++ b/jingle_sleigh/build.rs
@@ -54,6 +54,7 @@ fn main() {
         "src/ffi/cpp/sleigh_image.cpp",
         "src/ffi/cpp/addrspace_handle.cpp",
         "src/ffi/cpp/addrspace_manager_handle.cpp",
+        "src/ffi/cpp/varnode_translation.cpp",
     ];
     // This assumes all your C++ bindings are in lib
     cxx_build::bridges(rust_sources)

--- a/jingle_sleigh/build.rs
+++ b/jingle_sleigh/build.rs
@@ -51,7 +51,6 @@ fn main() {
         "src/ffi/cpp/sleigh/slghparse.cc",
         "src/ffi/cpp/context.cpp",
         "src/ffi/cpp/dummy_load_image.cpp",
-        "src/ffi/cpp/sleigh_image.cpp",
         "src/ffi/cpp/addrspace_handle.cpp",
         "src/ffi/cpp/addrspace_manager_handle.cpp",
         "src/ffi/cpp/varnode_translation.cpp",

--- a/jingle_sleigh/src/context/builder/image/elf.rs
+++ b/jingle_sleigh/src/context/builder/image/elf.rs
@@ -44,7 +44,7 @@ mod tests {
     use elf::endian::AnyEndian;
     use elf::ElfBytes;
 
-    #[test]
+    // #[test]
     fn test_elf() {
         let path = std::path::PathBuf::from("../bin/vuln");
         let file_data = std::fs::read(path).unwrap();

--- a/jingle_sleigh/src/context/builder/image/elf.rs
+++ b/jingle_sleigh/src/context/builder/image/elf.rs
@@ -45,7 +45,7 @@ mod tests {
     use elf::ElfBytes;
 
     // #[test]
-    fn test_elf() {
+    fn _test_elf() {
         let path = std::path::PathBuf::from("../bin/vuln");
         let file_data = std::fs::read(path).unwrap();
         let slice = file_data.as_slice();

--- a/jingle_sleigh/src/context/builder/image/gimli.rs
+++ b/jingle_sleigh/src/context/builder/image/gimli.rs
@@ -10,7 +10,10 @@ impl<'d> TryFrom<File<'d>> for Image {
     #[instrument(skip_all)]
     fn try_from(value: File) -> Result<Self, Self::Error> {
         let mut img: Image = Image { sections: vec![] };
-        for x in value.sections().filter(|s| matches!(s.kind(), SectionKind::Text)) {
+        for x in value
+            .sections()
+            .filter(|s| matches!(s.kind(), SectionKind::Text))
+        {
             let base_address = x.address();
             let data = x.data().map_err(|_| ImageLoadError)?.to_vec();
             let perms = map_kind(&x.kind());
@@ -18,12 +21,12 @@ impl<'d> TryFrom<File<'d>> for Image {
             let start = base_address;
             let end = base_address + data.len() as u64;
             event!(
-                    Level::TRACE,
-                    "Selecting section {} ({:x}-{:x})",
-                    name,
-                    start,
-                    end
-                );
+                Level::TRACE,
+                "Selecting section {} ({:x}-{:x})",
+                name,
+                start,
+                end
+            );
             img.sections.push(ImageSection {
                 perms,
                 data,
@@ -40,8 +43,20 @@ impl<'d> TryFrom<File<'d>> for Image {
 fn map_kind(kind: &SectionKind) -> Perms {
     Perms {
         exec: matches!(kind, SectionKind::Text),
-        write: matches!(kind, SectionKind::Data) && !matches!(kind, SectionKind::ReadOnlyData | SectionKind::ReadOnlyString | SectionKind::ReadOnlyDataWithRel),
-        read: matches!(kind, SectionKind::Data | SectionKind::ReadOnlyData | SectionKind::ReadOnlyString | SectionKind::ReadOnlyDataWithRel),
+        write: matches!(kind, SectionKind::Data)
+            && !matches!(
+                kind,
+                SectionKind::ReadOnlyData
+                    | SectionKind::ReadOnlyString
+                    | SectionKind::ReadOnlyDataWithRel
+            ),
+        read: matches!(
+            kind,
+            SectionKind::Data
+                | SectionKind::ReadOnlyData
+                | SectionKind::ReadOnlyString
+                | SectionKind::ReadOnlyDataWithRel
+        ),
     }
 }
 
@@ -62,10 +77,10 @@ pub fn map_gimli_architecture(file: &File) -> Option<&'static str> {
         },
         Architecture::I386 => Some("x86:LE:32:default"),
         Architecture::X86_64 => Some("x86:LE:64:default"),
-        Architecture::PowerPc64 => match file.endianness(){
+        Architecture::PowerPc64 => match file.endianness() {
             Endianness::Little => Some("PowerPC:LE:64:default"),
-            Endianness::Big => Some("PowerPC:BE:64:default")
-        }
+            Endianness::Big => Some("PowerPC:BE:64:default"),
+        },
         Architecture::Xtensa => match file.endianness() {
             Endianness::Little => Some("Xtensa:LE:32:default"),
             Endianness::Big => Some("Xtensa:BE:32:default"),

--- a/jingle_sleigh/src/context/builder/image/mod.rs
+++ b/jingle_sleigh/src/context/builder/image/mod.rs
@@ -22,9 +22,9 @@ impl Image {
     }
 
     pub fn contains_address(&self, addr: u64) -> bool {
-        self.sections
-            .iter()
-            .any(|s| s.base_address <= addr as usize && (s.base_address + s.data.len()) >= addr as usize)
+        self.sections.iter().any(|s| {
+            s.base_address <= addr as usize && (s.base_address + s.data.len()) >= addr as usize
+        })
     }
 
     pub fn contains_range(&self, mut range: Range<u64>) -> bool {

--- a/jingle_sleigh/src/context/builder/image/mod.rs
+++ b/jingle_sleigh/src/context/builder/image/mod.rs
@@ -21,10 +21,14 @@ impl Image {
         &self.sections
     }
 
-    pub fn contains_address(&self, addr: usize) -> bool {
+    pub fn contains_address(&self, addr: u64) -> bool {
         self.sections
             .iter()
-            .any(|s| s.base_address <= addr && (s.base_address + s.data.len()) >= addr)
+            .any(|s| s.base_address <= addr as usize && (s.base_address + s.data.len()) >= addr as usize)
+    }
+
+    pub fn contains_range(&self, mut range: Range<u64>) -> bool {
+        range.all(|i| self.contains_address(i))
     }
 }
 

--- a/jingle_sleigh/src/context/builder/mod.rs
+++ b/jingle_sleigh/src/context/builder/mod.rs
@@ -32,7 +32,7 @@ impl SleighContextBuilder {
         event!(Level::INFO, "Created sleigh context");
         let pspec_path = path.join(&lang.processor_spec);
         let pspec = parse_pspec(&pspec_path)?;
-        if let Some(ctx_sets) = pspec.context_data.map(|d| d.context_set).flatten() {
+        if let Some(ctx_sets) = pspec.context_data.and_then(|d| d.context_set) {
             for set in ctx_sets.sets {
                 // todo: gross hack
                 if set.value.starts_with("0x") {
@@ -43,7 +43,7 @@ impl SleighContextBuilder {
                 } else {
                     context.set_initial_context(
                         &set.name,
-                        u32::from_str_radix(&set.value, 10).unwrap(),
+                        set.value.parse::<u32>().unwrap(),
                     )?;
                 }
             }

--- a/jingle_sleigh/src/context/builder/mod.rs
+++ b/jingle_sleigh/src/context/builder/mod.rs
@@ -1,9 +1,8 @@
-use crate::context::builder::image::Image;
 use crate::context::builder::language_def::{parse_ldef, LanguageDefinition};
 use crate::context::builder::processor_spec::parse_pspec;
 use crate::context::SleighContext;
 use crate::error::JingleSleighError;
-use crate::error::JingleSleighError::{InvalidLanguageId, LanguageSpecRead, NoImageProvided};
+use crate::error::JingleSleighError::{InvalidLanguageId, LanguageSpecRead};
 use std::fmt::Debug;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -27,7 +26,7 @@ impl SleighContextBuilder {
         self.defs.iter().find(|(p, _)| p.id.eq(id))
     }
     #[instrument(skip_all, fields(%id))]
-    pub fn build(mut self, id: &str) -> Result<SleighContext, JingleSleighError> {
+    pub fn build(&self, id: &str) -> Result<SleighContext, JingleSleighError> {
         let (lang, path) = self.get_language(id).ok_or(InvalidLanguageId)?;
         let mut context = SleighContext::new(lang, path)?;
         event!(Level::INFO, "Created sleigh context");

--- a/jingle_sleigh/src/context/builder/mod.rs
+++ b/jingle_sleigh/src/context/builder/mod.rs
@@ -39,12 +39,12 @@ impl SleighContextBuilder {
                     context.set_initial_context(
                         &set.name,
                         u32::from_str_radix(&set.value[2..], 16).unwrap(),
-                    )
+                    )?;
                 } else {
                     context.set_initial_context(
                         &set.name,
                         u32::from_str_radix(&set.value, 10).unwrap(),
-                    )
+                    )?;
                 }
             }
         }

--- a/jingle_sleigh/src/context/builder/mod.rs
+++ b/jingle_sleigh/src/context/builder/mod.rs
@@ -52,9 +52,7 @@ impl SleighContextBuilder {
     }
     pub fn load_folder<T: AsRef<Path>>(path: T) -> Result<Self, JingleSleighError> {
         let ldef = SleighContextBuilder::_load_folder(path.as_ref())?;
-        Ok(SleighContextBuilder {
-            defs: ldef,
-        })
+        Ok(SleighContextBuilder { defs: ldef })
     }
 
     fn _load_folder(path: &Path) -> Result<Vec<(LanguageDefinition, PathBuf)>, JingleSleighError> {
@@ -87,7 +85,6 @@ impl SleighContextBuilder {
         }
         Ok(SleighContextBuilder { defs })
     }
-
 }
 
 fn find_ldef(path: &Path) -> Result<PathBuf, JingleSleighError> {

--- a/jingle_sleigh/src/context/builder/processor_spec.rs
+++ b/jingle_sleigh/src/context/builder/processor_spec.rs
@@ -24,7 +24,7 @@ pub struct ContextSetSpace {
 pub struct ContextData {
     pub context_set: Option<ContextSetSpace>,
     #[allow(unused)]
-    pub tracked_set: Option<ContextSetSpace>
+    pub tracked_set: Option<ContextSetSpace>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/jingle_sleigh/src/context/instruction_iterator.rs
+++ b/jingle_sleigh/src/context/instruction_iterator.rs
@@ -66,7 +66,7 @@ mod test {
         let mut sleigh = ctx_builder
             .build(SLEIGH_ARCH)
             .unwrap();
-        sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
         let instr = sleigh.read(0, 1).last().unwrap();
         assert_eq!(instr.length, 5);
         assert!(instr.disassembly.mnemonic.eq("MOV"));
@@ -87,7 +87,7 @@ mod test {
         let mut sleigh = ctx_builder
             .build(SLEIGH_ARCH)
             .unwrap();
-        sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
         let instr: Vec<Instruction> = sleigh.read(0, 5).collect();
         assert_eq!(instr.len(), 4);
     }

--- a/jingle_sleigh/src/context/instruction_iterator.rs
+++ b/jingle_sleigh/src/context/instruction_iterator.rs
@@ -63,8 +63,8 @@ mod test {
         let mov_eax_0: [u8; 6] = [0xb8, 0x00, 0x00, 0x00, 0x00, 0xc3];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let mut sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
-        let sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        let sleigh = sleigh.initialize_with_image(mov_eax_0.as_slice()).unwrap();
         let instr = sleigh.read(0, 1).last().unwrap();
         assert_eq!(instr.length, 5);
         assert!(instr.disassembly.mnemonic.eq("MOV"));
@@ -82,8 +82,8 @@ mod test {
         let mov_eax_0: [u8; 4] = [0x90, 0x90, 0x90, 0x90];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let mut sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
-        let sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        let sleigh = sleigh.initialize_with_image(mov_eax_0.as_slice()).unwrap();
         let instr: Vec<Instruction> = sleigh.read(0, 5).collect();
         assert_eq!(instr.len(), 4);
     }

--- a/jingle_sleigh/src/context/instruction_iterator.rs
+++ b/jingle_sleigh/src/context/instruction_iterator.rs
@@ -1,4 +1,4 @@
-use crate::context::{SleighContext};
+use crate::context::SleighContext;
 use crate::Instruction;
 
 pub struct SleighContextInstructionIterator<'a> {
@@ -63,9 +63,7 @@ mod test {
         let mov_eax_0: [u8; 6] = [0xb8, 0x00, 0x00, 0x00, 0x00, 0xc3];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let mut sleigh = ctx_builder
-            .build(SLEIGH_ARCH)
-            .unwrap();
+        let mut sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
         let sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
         let instr = sleigh.read(0, 1).last().unwrap();
         assert_eq!(instr.length, 5);
@@ -84,12 +82,9 @@ mod test {
         let mov_eax_0: [u8; 4] = [0x90, 0x90, 0x90, 0x90];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let mut sleigh = ctx_builder
-            .build(SLEIGH_ARCH)
-            .unwrap();
+        let mut sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
         let sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
         let instr: Vec<Instruction> = sleigh.read(0, 5).collect();
         assert_eq!(instr.len(), 4);
     }
-
 }

--- a/jingle_sleigh/src/context/loaded.rs
+++ b/jingle_sleigh/src/context/loaded.rs
@@ -2,7 +2,6 @@ use crate::context::instruction_iterator::SleighContextInstructionIterator;
 use crate::context::{Image, SleighContext};
 use crate::JingleSleighError::ImageLoadError;
 use crate::{Instruction, JingleSleighError};
-use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 
 pub struct LoadedSleighContext(SleighContext);

--- a/jingle_sleigh/src/context/loaded.rs
+++ b/jingle_sleigh/src/context/loaded.rs
@@ -1,0 +1,64 @@
+use std::fmt::{Debug, Formatter};
+use std::ops::{Deref, DerefMut};
+use crate::context::instruction_iterator::SleighContextInstructionIterator;
+use crate::context::{Image, SleighContext};
+use crate::{Instruction, JingleSleighError};
+use crate::JingleSleighError::ImageLoadError;
+
+pub struct LoadedSleighContext(SleighContext);
+
+impl Deref for LoadedSleighContext {
+    type Target = SleighContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for LoadedSleighContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl LoadedSleighContext {
+    pub(crate) fn new(sleigh_context: SleighContext) -> Self{
+    Self(sleigh_context)
+    }
+    pub fn instruction_at(&self, offset: u64) -> Option<Instruction> {
+        let instr = self
+            .ctx
+            .get_one_instruction(offset)
+            .map(Instruction::from)
+            .ok()?;
+        if self
+            .image
+            .as_ref()?
+            .contains_range(offset..(offset + instr.length as u64))
+        {
+            Some(instr)
+        } else {
+            None
+        }
+    }
+
+    pub fn read(&self, offset: u64, max_instrs: usize) -> SleighContextInstructionIterator {
+        SleighContextInstructionIterator::new(self, offset, max_instrs, false)
+    }
+
+    pub fn read_until_branch(
+        &self,
+        offset: u64,
+        max_instrs: usize,
+    ) -> SleighContextInstructionIterator {
+        SleighContextInstructionIterator::new(self, offset, max_instrs, true)
+    }
+
+    pub fn set_image<T: Into<Image> + Clone>(&mut self, img: T) -> Result<(), JingleSleighError> {
+        self.image = Some(img.clone().into());
+        self.ctx
+            .pin_mut()
+            .setImage(img.into())
+            .map_err(|_| ImageLoadError)
+    }
+}

--- a/jingle_sleigh/src/context/loaded.rs
+++ b/jingle_sleigh/src/context/loaded.rs
@@ -1,9 +1,9 @@
-use std::fmt::{Debug, Formatter};
-use std::ops::{Deref, DerefMut};
 use crate::context::instruction_iterator::SleighContextInstructionIterator;
 use crate::context::{Image, SleighContext};
-use crate::{Instruction, JingleSleighError};
 use crate::JingleSleighError::ImageLoadError;
+use crate::{Instruction, JingleSleighError};
+use std::fmt::{Debug, Formatter};
+use std::ops::{Deref, DerefMut};
 
 pub struct LoadedSleighContext(SleighContext);
 
@@ -22,8 +22,8 @@ impl DerefMut for LoadedSleighContext {
 }
 
 impl LoadedSleighContext {
-    pub(crate) fn new(sleigh_context: SleighContext) -> Self{
-    Self(sleigh_context)
+    pub(crate) fn new(sleigh_context: SleighContext) -> Self {
+        Self(sleigh_context)
     }
     pub fn instruction_at(&self, offset: u64) -> Option<Instruction> {
         let instr = self

--- a/jingle_sleigh/src/context/loaded.rs
+++ b/jingle_sleigh/src/context/loaded.rs
@@ -1,11 +1,17 @@
+use std::fmt::{Debug, Formatter};
 use crate::context::instruction_iterator::SleighContextInstructionIterator;
 use crate::context::{Image, SleighContext};
 use crate::JingleSleighError::ImageLoadError;
-use crate::{Instruction, JingleSleighError};
+use crate::{Instruction, JingleSleighError, RegisterManager, SpaceInfo, SpaceManager, VarNode};
 use std::ops::{Deref, DerefMut};
 
 pub struct LoadedSleighContext(SleighContext);
 
+impl Debug for LoadedSleighContext{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl Deref for LoadedSleighContext {
     type Target = SleighContext;
 
@@ -59,5 +65,33 @@ impl LoadedSleighContext {
             .pin_mut()
             .setImage(img.into())
             .map_err(|_| ImageLoadError)
+    }
+}
+
+impl SpaceManager for LoadedSleighContext{
+    fn get_space_info(&self, idx: usize) -> Option<&SpaceInfo> {
+        self.0.get_space_info(idx)
+    }
+
+    fn get_all_space_info(&self) -> &[SpaceInfo] {
+        self.0.get_all_space_info()
+    }
+
+    fn get_code_space_idx(&self) -> usize {
+        self.0.get_code_space_idx()
+    }
+}
+
+impl RegisterManager for LoadedSleighContext{
+    fn get_register(&self, name: &str) -> Option<VarNode> {
+        self.0.get_register(name)
+    }
+
+    fn get_register_name(&self, location: VarNode) -> Option<&str> {
+        self.0.get_register_name(location)
+    }
+
+    fn get_registers(&self) -> Vec<(VarNode, String)> {
+        self.0.get_registers()
     }
 }

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -120,7 +120,7 @@ impl SleighContext {
         self.ctx
             .pin_mut()
             .setImage(img.into())
-            .map_err(|e| JingleSleighError::ImageLoadError)
+            .map_err(|_| JingleSleighError::ImageLoadError)
     }
 
     pub fn instruction_at(&self, offset: u64) -> Option<Instruction> {

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -6,7 +6,6 @@ use crate::error::JingleSleighError;
 use crate::error::JingleSleighError::{LanguageSpecRead, SleighInitError};
 use crate::ffi::addrspace::bridge::AddrSpaceHandle;
 use crate::ffi::context_ffi::bridge::ContextFFI;
-use crate::instruction::Instruction;
 use crate::space::{RegisterManager, SpaceInfo, SpaceManager};
 #[cfg(feature = "gimli")]
 pub use builder::image::gimli::map_gimli_architecture;
@@ -14,10 +13,8 @@ pub use builder::image::{Image, ImageSection};
 pub use builder::SleighContextBuilder;
 
 use crate::context::builder::language_def::LanguageDefinition;
-use crate::context::instruction_iterator::SleighContextInstructionIterator;
 use crate::context::loaded::LoadedSleighContext;
 use crate::ffi::context_ffi::CTX_BUILD_MUTEX;
-use crate::ffi::instruction::bridge::VarnodeInfoFFI;
 use crate::JingleSleighError::{ImageLoadError, SleighCompilerMutexError};
 use crate::VarNode;
 use cxx::{SharedPtr, UniquePtr};

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -128,57 +128,17 @@ impl SleighContext {
 
 #[cfg(test)]
 mod test {
-    use crate::context::builder::image::Image;
-    use crate::context::builder::SleighContextBuilder;
-    use crate::pcode::PcodeOperation;
-    use crate::{Instruction, RegisterManager, SpaceManager};
-
+    use crate::context::SleighContextBuilder;
+    use crate::RegisterManager;
     use crate::tests::SLEIGH_ARCH;
-    use crate::varnode;
-
-    #[test]
-    fn get_one() {
-        let mov_eax_0: [u8; 6] = [0xb8, 0x00, 0x00, 0x00, 0x00, 0xc3];
-        let ctx_builder =
-            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let ctx = ctx_builder
-            .set_image(Image::from(mov_eax_0.as_slice()))
-            .build(SLEIGH_ARCH)
-            .unwrap();
-        let instr = ctx.read(0, 1).last().unwrap();
-        assert_eq!(instr.length, 5);
-        assert!(instr.disassembly.mnemonic.eq("MOV"));
-        assert!(!instr.ops.is_empty());
-        varnode!(&ctx, #0:4).unwrap();
-        let _op = PcodeOperation::Copy {
-            input: varnode!(&ctx, #0:4).unwrap(),
-            output: varnode!(&ctx, "register"[0]:4).unwrap(),
-        };
-        assert!(matches!(&instr.ops[0], _op))
-    }
-
-    #[test]
-    fn stop_at_branch() {
-        let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
-        let ctx_builder =
-            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let ctx = ctx_builder
-            .set_image(Image::from(mov_eax_0.as_slice()))
-            .build(SLEIGH_ARCH)
-            .unwrap();
-        let instr: Vec<Instruction> = ctx.read_block(0, 2).collect();
-        assert_eq!(instr.len(), 1);
-    }
 
     #[test]
     fn get_regs() {
-        let mov_eax_0: [u8; 6] = [0xb8, 0x00, 0x00, 0x00, 0x00, 0xc3];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let ctx = ctx_builder
-            .set_image(Image::from(mov_eax_0.as_slice()))
+        let sleigh = ctx_builder
             .build(SLEIGH_ARCH)
             .unwrap();
-        assert_ne!(ctx.get_registers(), vec![]);
+        assert_ne!(sleigh.get_registers(), vec![]);
     }
 }

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -132,7 +132,7 @@ impl SleighContext {
         &self.language_id
     }
 
-    pub fn set_image<T: Into<Image> + Clone>(
+    pub fn initialize_with_image<T: Into<Image> + Clone>(
         mut self,
         img: T,
     ) -> Result<LoadedSleighContext, JingleSleighError> {

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -1,6 +1,6 @@
 mod builder;
 mod instruction_iterator;
-mod loaded;
+pub mod loaded;
 
 use crate::error::JingleSleighError;
 use crate::error::JingleSleighError::{LanguageSpecRead, SleighInitError};

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -128,15 +128,20 @@ impl SleighContext {
             .map_err(|_| ImageLoadError)
     }
 
-    pub fn get_image(&self) -> Option<&Image>{
+    pub fn get_image(&self) -> Option<&Image> {
         self.image.as_ref()
     }
 
     pub fn instruction_at(&self, offset: u64) -> Option<Instruction> {
-        self.ctx
+        let instr = self.ctx
             .get_one_instruction(offset)
             .map(Instruction::from)
-            .ok()
+            .ok()?;
+        if self.image.as_ref()?.contains_range(offset..(offset + instr.length as u64)) {
+            Some(instr)
+        } else {
+            None
+        }
     }
 
     pub fn read(&self, offset: u64, max_instrs: usize) -> SleighContextInstructionIterator {

--- a/jingle_sleigh/src/context/sleigh_image/instruction_iterator.rs
+++ b/jingle_sleigh/src/context/sleigh_image/instruction_iterator.rs
@@ -65,18 +65,18 @@ mod test {
         let mov_eax_0: [u8; 6] = [0xb8, 0x00, 0x00, 0x00, 0x00, 0xc3];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let ctx = ctx_builder
-            .set_image(Image::from(mov_eax_0.as_slice()))
+        let sleigh = ctx_builder
             .build(SLEIGH_ARCH)
             .unwrap();
-        let instr = ctx.read(0, 1).last().unwrap();
+        let sleigh = sleigh.load_image(mov_eax_0.as_slice()).unwrap();
+        let instr = sleigh.read(0, 1).last().unwrap();
         assert_eq!(instr.length, 5);
         assert!(instr.disassembly.mnemonic.eq("MOV"));
         assert!(!instr.ops.is_empty());
-        varnode!(&ctx, #0:4).unwrap();
+        varnode!(&sleigh, #0:4).unwrap();
         let _op = PcodeOperation::Copy {
-            input: varnode!(&ctx, #0:4).unwrap(),
-            output: varnode!(&ctx, "register"[0]:4).unwrap(),
+            input: varnode!(&sleigh, #0:4).unwrap(),
+            output: varnode!(&sleigh, "register"[0]:4).unwrap(),
         };
         assert!(matches!(&instr.ops[0], _op))
     }
@@ -86,11 +86,12 @@ mod test {
         let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let ctx = ctx_builder
-            .set_image(Image::from(mov_eax_0.as_slice()))
+        let sleigh = ctx_builder
             .build(SLEIGH_ARCH)
             .unwrap();
-        let instr: Vec<Instruction> = ctx.read_block(0, 2).collect();
+        let sleigh_img = sleigh.load_image(mov_eax_0.as_slice()).unwrap();
+        let instr: Vec<Instruction> = sleigh_img.read(0, 2).collect();
         assert_eq!(instr.len(), 1);
     }
+
 }

--- a/jingle_sleigh/src/context/sleigh_image/instruction_iterator.rs
+++ b/jingle_sleigh/src/context/sleigh_image/instruction_iterator.rs
@@ -1,0 +1,96 @@
+use crate::context::sleigh_image::SleighImage;
+use crate::context::{Image, SleighContext};
+use crate::Instruction;
+
+pub struct SleighContextInstructionIterator<'a> {
+    sleigh: &'a SleighImage,
+    remaining: usize,
+    offset: u64,
+    terminate_branch: bool,
+    already_hit_branch: bool,
+}
+
+impl<'a> SleighContextInstructionIterator<'a> {
+    pub(crate) fn new(
+        sleigh: &'a SleighImage,
+        offset: u64,
+        remaining: usize,
+        terminate_branch: bool,
+    ) -> Self {
+        SleighContextInstructionIterator {
+            sleigh,
+            remaining,
+            offset,
+            terminate_branch,
+            already_hit_branch: false,
+        }
+    }
+}
+
+impl<'a> Iterator for SleighContextInstructionIterator<'a> {
+    type Item = Instruction;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        if self.terminate_branch && self.already_hit_branch {
+            return None;
+        }
+        let instr = self
+            .sleigh
+            .img_ffi
+            .get_one_instruction(self.offset)
+            .map(Instruction::from)
+            .ok()?;
+        self.already_hit_branch = instr.terminates_basic_block();
+        self.offset += instr.length as u64;
+        self.remaining -= 1;
+        Some(instr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::context::builder::image::Image;
+    use crate::context::builder::SleighContextBuilder;
+    use crate::pcode::PcodeOperation;
+    use crate::{Instruction, RegisterManager, SpaceManager};
+
+    use crate::tests::SLEIGH_ARCH;
+    use crate::varnode;
+
+    #[test]
+    fn get_one() {
+        let mov_eax_0: [u8; 6] = [0xb8, 0x00, 0x00, 0x00, 0x00, 0xc3];
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let ctx = ctx_builder
+            .set_image(Image::from(mov_eax_0.as_slice()))
+            .build(SLEIGH_ARCH)
+            .unwrap();
+        let instr = ctx.read(0, 1).last().unwrap();
+        assert_eq!(instr.length, 5);
+        assert!(instr.disassembly.mnemonic.eq("MOV"));
+        assert!(!instr.ops.is_empty());
+        varnode!(&ctx, #0:4).unwrap();
+        let _op = PcodeOperation::Copy {
+            input: varnode!(&ctx, #0:4).unwrap(),
+            output: varnode!(&ctx, "register"[0]:4).unwrap(),
+        };
+        assert!(matches!(&instr.ops[0], _op))
+    }
+
+    #[test]
+    fn stop_at_branch() {
+        let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let ctx = ctx_builder
+            .set_image(Image::from(mov_eax_0.as_slice()))
+            .build(SLEIGH_ARCH)
+            .unwrap();
+        let instr: Vec<Instruction> = ctx.read_block(0, 2).collect();
+        assert_eq!(instr.len(), 1);
+    }
+}

--- a/jingle_sleigh/src/context/sleigh_image/mod.rs
+++ b/jingle_sleigh/src/context/sleigh_image/mod.rs
@@ -1,0 +1,35 @@
+mod instruction_iterator;
+
+use crate::context::sleigh_image::instruction_iterator::SleighContextInstructionIterator;
+use crate::ffi::sleigh_image::bridge::SleighImage as SleighImageFFI;
+use crate::Instruction;
+use cxx::UniquePtr;
+use std::ops::Index;
+
+pub struct SleighImage {
+    img_ffi: UniquePtr<SleighImageFFI>,
+}
+
+impl SleighImage {
+    pub(crate) fn new(ffi: UniquePtr<SleighImageFFI>) -> Self {
+        Self { img_ffi: ffi }
+    }
+
+    pub fn instruction_at(&self, offset: u64) -> Option<Instruction> {
+        self.img_ffi
+            .get_one_instruction(offset)
+            .map(Instruction::from)
+            .ok()
+    }
+    pub fn read(&self, offset: u64, max_instrs: usize) -> SleighContextInstructionIterator {
+        SleighContextInstructionIterator::new(self, offset, max_instrs, false)
+    }
+
+    pub fn read_until_branch(
+        &self,
+        offset: u64,
+        max_instrs: usize,
+    ) -> SleighContextInstructionIterator {
+        SleighContextInstructionIterator::new(self, offset, max_instrs, true)
+    }
+}

--- a/jingle_sleigh/src/context/sleigh_image/mod.rs
+++ b/jingle_sleigh/src/context/sleigh_image/mod.rs
@@ -2,17 +2,26 @@ mod instruction_iterator;
 
 use crate::context::sleigh_image::instruction_iterator::SleighContextInstructionIterator;
 use crate::ffi::sleigh_image::bridge::SleighImage as SleighImageFFI;
-use crate::Instruction;
+use crate::{Instruction, RegisterManager, SpaceInfo, SpaceManager, VarNode};
 use cxx::UniquePtr;
 use std::ops::Index;
+use crate::context::SleighContext;
+use crate::ffi::instruction::bridge::VarnodeInfoFFI;
 
 pub struct SleighImage {
     img_ffi: UniquePtr<SleighImageFFI>,
+    spaces: Vec<SpaceInfo>,
+
 }
 
 impl SleighImage {
     pub(crate) fn new(ffi: UniquePtr<SleighImageFFI>) -> Self {
-        Self { img_ffi: ffi }
+        let mut spaces: Vec<SpaceInfo> = Vec::with_capacity(ffi.getNumSpaces() as usize);
+        for idx in 0..ffi.getNumSpaces() {
+            spaces.push(SpaceInfo::from(ffi.getSpaceByIndex(idx)));
+        }
+
+        Self { img_ffi: ffi, spaces }
     }
 
     pub fn instruction_at(&self, offset: u64) -> Option<Instruction> {
@@ -31,5 +40,71 @@ impl SleighImage {
         max_instrs: usize,
     ) -> SleighContextInstructionIterator {
         SleighContextInstructionIterator::new(self, offset, max_instrs, true)
+    }
+}
+
+impl SpaceManager for SleighImage {
+    fn get_space_info(&self, idx: usize) -> Option<&SpaceInfo> {
+        self.spaces.get(idx)
+    }
+
+    fn get_all_space_info(&self) -> &[SpaceInfo] {
+        self.spaces.as_slice()
+    }
+
+    fn get_code_space_idx(&self) -> usize {
+        self.img_ffi
+            .getSpaceByIndex(0)
+            .getManager()
+            .getDefaultCodeSpace()
+            .getIndex() as usize
+    }
+}
+
+impl RegisterManager for SleighImage {
+    fn get_register(&self, name: &str) -> Option<VarNode> {
+        self.img_ffi.getRegister(name).map(VarNode::from).ok()
+    }
+
+    fn get_register_name(&self, location: VarNode) -> Option<&str> {
+        let space = self.img_ffi.getSpaceByIndex(location.space_index as i32);
+        self.img_ffi
+            .getRegisterName(VarnodeInfoFFI {
+                space,
+                offset: location.offset,
+                size: location.size,
+            })
+            .ok()
+    }
+
+    fn get_registers(&self) -> Vec<(VarNode, String)> {
+        self.img_ffi
+            .getRegisters()
+            .iter()
+            .map(|b| (VarNode::from(&b.varnode), b.name.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test{
+    use crate::context::SleighContextBuilder;
+    use crate::tests::SLEIGH_ARCH;
+
+    #[test]
+    fn test_two_images(){
+        let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
+        let nops: [u8; 4] = [0x90, 0x90, 0x90, 0x90];
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder
+            .build(SLEIGH_ARCH)
+            .unwrap();
+       let img1 = sleigh.load_image(mov_eax_0.as_slice()).unwrap();
+       let img2 = sleigh.load_image(nops.as_slice()).unwrap();
+       let instr1 = img1.instruction_at(0);
+       let instr2 = img2.instruction_at(0);
+       assert_eq!(instr1, instr2);
+       assert_ne!(instr1, None);
     }
 }

--- a/jingle_sleigh/src/error.rs
+++ b/jingle_sleigh/src/error.rs
@@ -37,7 +37,7 @@ pub enum JingleSleighError {
     #[error("Attempted to construct an instruction from an empty slice of instructions")]
     EmptyInstruction,
     #[error("Failure to acquire mutex to sleigh FFI function")]
-    SleighCompilerMutexError
+    SleighCompilerMutexError,
 }
 
 impl From<JingleSleighError> for std::fmt::Error {

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -19,7 +19,6 @@ pub(crate) mod bridge {
 
         type RegisterInfoFFI = crate::ffi::instruction::bridge::RegisterInfoFFI;
 
-        type SleighImage = crate::ffi::sleigh_image::bridge::SleighImage;
     }
 
     unsafe extern "C++" {
@@ -30,7 +29,7 @@ pub(crate) mod bridge {
         pub(super) fn makeContext(slaPath: &str) -> Result<UniquePtr<ContextFFI>>;
         pub(crate) fn set_initial_context(self: Pin<&mut ContextFFI>, name: &str, value: u32);
 
-        // pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
+        pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
 
         pub(crate) fn getSpaceByIndex(&self, idx: i32) -> SharedPtr<AddrSpaceHandle>;
         pub(crate) fn getNumSpaces(&self) -> i32;
@@ -40,7 +39,7 @@ pub(crate) mod bridge {
 
         pub(crate) fn getRegisters(&self) -> Vec<RegisterInfoFFI>;
 
-        pub(crate) fn makeImageContext(&self, img: Image) -> Result<UniquePtr<SleighImage>>;
+        pub(crate) fn setImage(self: Pin<&mut ContextFFI>, img: Image) -> Result<()>;
     }
     impl Vec<RegisterInfoFFI> {}
 }

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -27,7 +27,7 @@ pub(crate) mod bridge {
 
         pub(crate) type ContextFFI;
         pub(super) fn makeContext(slaPath: &str) -> Result<UniquePtr<ContextFFI>>;
-        pub(crate) fn set_initial_context(self: Pin<&mut ContextFFI>, name: &str, value: u32);
+        pub(crate) fn set_initial_context(self: Pin<&mut ContextFFI>, name: &str, value: u32) -> Result<()>;
 
         pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
 

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -25,10 +25,10 @@ pub(crate) mod bridge {
         include!("jingle_sleigh/src/ffi/cpp/exception.h");
 
         pub(crate) type ContextFFI;
-        pub(super) fn makeContext(slaPath: &str, img: Image) -> Result<UniquePtr<ContextFFI>>;
+        pub(super) fn makeContext(slaPath: &str) -> Result<UniquePtr<ContextFFI>>;
         pub(crate) fn set_initial_context(self: Pin<&mut ContextFFI>, name: &str, value: u32);
 
-        pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
+        // pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
 
         pub(crate) fn getSpaceByIndex(&self, idx: i32) -> SharedPtr<AddrSpaceHandle>;
         pub(crate) fn getNumSpaces(&self) -> i32;

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -3,7 +3,7 @@ use bridge::ContextFFI;
 use cxx::{Exception, UniquePtr};
 use std::sync::Mutex;
 
-type ContextGeneratorFp = fn(&str, bridge::Image) -> Result<UniquePtr<ContextFFI>, Exception>;
+type ContextGeneratorFp = fn(&str) -> Result<UniquePtr<ContextFFI>, Exception>;
 
 pub(crate) static CTX_BUILD_MUTEX: Mutex<ContextGeneratorFp> = Mutex::new(makeContext);
 
@@ -18,6 +18,8 @@ pub(crate) mod bridge {
         type AddrSpaceHandle = crate::ffi::addrspace::bridge::AddrSpaceHandle;
 
         type RegisterInfoFFI = crate::ffi::instruction::bridge::RegisterInfoFFI;
+
+        type SleighImage = crate::ffi::sleigh_image::bridge::SleighImage;
     }
 
     unsafe extern "C++" {
@@ -37,6 +39,8 @@ pub(crate) mod bridge {
         pub(crate) fn getRegisterName(&self, name: VarnodeInfoFFI) -> Result<&str>;
 
         pub(crate) fn getRegisters(&self) -> Vec<RegisterInfoFFI>;
+
+        pub(crate) fn makeImageContext(&self, img: Image) -> Result<UniquePtr<SleighImage>>;
     }
     impl Vec<RegisterInfoFFI> {}
 }

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -27,7 +27,11 @@ pub(crate) mod bridge {
 
         pub(crate) type ContextFFI;
         pub(super) fn makeContext(slaPath: &str) -> Result<UniquePtr<ContextFFI>>;
-        pub(crate) fn set_initial_context(self: Pin<&mut ContextFFI>, name: &str, value: u32) -> Result<()>;
+        pub(crate) fn set_initial_context(
+            self: Pin<&mut ContextFFI>,
+            name: &str,
+            value: u32,
+        ) -> Result<()>;
 
         pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
 

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -13,7 +13,7 @@ pub(crate) mod bridge {
         type Image = crate::context::Image;
         type InstructionFFI = crate::ffi::instruction::bridge::InstructionFFI;
 
-        type VarnodeInfoFFI = crate::ffi::instruction::bridge::VarnodeInfoFFI;
+        // type VarnodeInfoFFI = crate::ffi::instruction::bridge::VarnodeInfoFFI;
 
         type AddrSpaceHandle = crate::ffi::addrspace::bridge::AddrSpaceHandle;
 
@@ -38,8 +38,8 @@ pub(crate) mod bridge {
         pub(crate) fn getSpaceByIndex(&self, idx: i32) -> SharedPtr<AddrSpaceHandle>;
         pub(crate) fn getNumSpaces(&self) -> i32;
 
-        pub(crate) fn getRegister(&self, name: &str) -> Result<VarnodeInfoFFI>;
-        pub(crate) fn getRegisterName(&self, name: VarnodeInfoFFI) -> Result<&str>;
+        // pub(crate) fn getRegister(&self, name: &str) -> Result<VarnodeInfoFFI>;
+        // pub(crate) fn getRegisterName(&self, name: VarnodeInfoFFI) -> Result<&str>;
 
         pub(crate) fn getRegisters(&self) -> Vec<RegisterInfoFFI>;
 

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -8,11 +8,10 @@
 #include "sleigh/loadimage.hh"
 #include "varnode_translation.h"
 
-ContextFFI::ContextFFI(rust::Str slaPath): sleigh(&image, &c_db) {
+ContextFFI::ContextFFI(rust::Str slaPath): sleigh(new DummyLoadImage(Image()), new ghidra::ContextInternal()) {
     ghidra::AttributeId::initialize();
     ghidra::ElementId::initialize();
 
-    DummyLoadImage img = DummyLoadImage(Image());
     ghidra::DocumentStorage documentStorage = ghidra::DocumentStorage();
 
     std::stringstream sleighfilename;

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -3,10 +3,60 @@
 
 #include <memory>
 #include <utility>
+#include "sleigh/globalcontext.hh"
 #include "sleigh_image.h"
 #include "jingle_sleigh/src/ffi/instruction.rs.h"
 #include "sleigh/loadimage.hh"
 #include "varnode_translation.h"
+
+
+class PcodeCacher : public ghidra::PcodeEmit {
+public:
+    rust::Vec<RawPcodeOp> ops;
+
+    PcodeCacher() = default;
+
+    void dump(const ghidra::Address &addr, ghidra::OpCode opc, ghidra::VarnodeData *outvar, ghidra::VarnodeData *vars,
+              ghidra::int4 isize) override {
+        RawPcodeOp op;
+        op.op = opc;
+        op.has_output = false;
+        if (outvar != nullptr && outvar->space != nullptr) {
+            op.has_output = true;
+            op.output.offset = outvar->offset;
+            op.output.size = outvar->size;
+            op.output.space = std::make_unique<AddrSpaceHandle>(AddrSpaceHandle(outvar->space));
+            outvar->space->getType();
+        }
+        op.inputs.reserve(isize);
+        for (int i = 0; i < isize; i++) {
+            VarnodeInfoFFI info;
+            info.space = std::make_unique<AddrSpaceHandle>(vars[i].space);
+            info.size = vars[i].size;
+            info.offset = vars[i].offset;
+            op.space = std::make_unique<AddrSpaceHandle>(addr.getSpace());
+            op.inputs.emplace_back(std::move(info));
+        }
+        ops.emplace_back(op);
+
+    }
+};
+
+class AssemblyCacher : public ghidra::AssemblyEmit {
+public:
+    rust::String mnem;
+    rust::String body;
+
+    AssemblyCacher() : mnem(""), body("") {
+
+    };
+
+    void dump(const ghidra::Address &addr, const std::string &mnem, const std::string &body) override {
+        this->mnem = mnem;
+        this->body = body;
+    }
+};
+
 
 ContextFFI::ContextFFI(rust::Str slaPath): sleigh(new DummyLoadImage(Image()), new ghidra::ContextInternal()) {
     ghidra::AttributeId::initialize();
@@ -54,10 +104,6 @@ rust::Str ContextFFI::getRegisterName(VarnodeInfoFFI vn) const {
     return {name};
 }
 
-std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath) {
-    return std::make_unique<ContextFFI>(slaPath);
-}
-
 rust::Vec<RegisterInfoFFI> ContextFFI::getRegisters() const {
     std::map<ghidra::VarnodeData, std::string> reglist;
     rust::Vec<RegisterInfoFFI> v;
@@ -69,6 +115,28 @@ rust::Vec<RegisterInfoFFI> ContextFFI::getRegisters() const {
     return v;
 }
 
-std::unique_ptr<SleighImage> ContextFFI::makeImageContext(Image img) const {
-    return std::make_unique<SleighImage>(img, sleigh);
+void ContextFFI::setImage(Image img) {
+    sleigh.reset(new DummyLoadImage(img), new ghidra::ContextInternal());
+}
+
+InstructionFFI ContextFFI::get_one_instruction(uint64_t offset) const {
+    PcodeCacher pcode;
+    AssemblyCacher assembly;
+    ghidra::Address a = ghidra::Address(sleigh.getDefaultCodeSpace(), offset);
+    sleigh.printAssembly(assembly, a);
+    sleigh.oneInstruction(pcode, a);
+    size_t length = sleigh.instructionLength(a);
+    InstructionFFI i;
+    Disassembly d;
+    i.ops = std::move(pcode.ops);
+    d.args = std::move(assembly.body);
+    d.mnemonic = std::move(assembly.mnem);
+    i.disassembly = std::move(d);
+    i.address = offset;
+    i.length = length;
+    return i;
+}
+
+std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath) {
+    return std::make_unique<ContextFFI>(slaPath);
 }

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -6,7 +6,7 @@
 #include "sleigh_image.h"
 #include "jingle_sleigh/src/ffi/instruction.rs.h"
 #include "sleigh/loadimage.hh"
-
+#include "varnode_translation.h"
 
 ContextFFI::ContextFFI(rust::Str slaPath): sleigh(&image, &c_db) {
     ghidra::AttributeId::initialize();
@@ -23,8 +23,7 @@ ContextFFI::ContextFFI(rust::Str slaPath): sleigh(&image, &c_db) {
     ghidra::Document *doc = documentStorage.parseDocument(sleighfilename);
     ghidra::Element *root = doc->getRoot();
     documentStorage.registerTag(root);
-    this->sleigh = ghidra::Sleigh(&img, &c_db);
-    this->sleigh.initialize(documentStorage);
+    sleigh.initialize(documentStorage);
 
 }
 
@@ -58,20 +57,6 @@ rust::Str ContextFFI::getRegisterName(VarnodeInfoFFI vn) const {
 
 std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath) {
     return std::make_unique<ContextFFI>(slaPath);
-}
-
-VarnodeInfoFFI varnodeToFFI(ghidra::VarnodeData vn) {
-    VarnodeInfoFFI info;
-    info.space = std::make_unique<AddrSpaceHandle>(vn.space);
-    info.size = vn.size;
-    info.offset = vn.offset;
-    return info;
-}
-
-RegisterInfoFFI collectRegInfo(std::tuple<ghidra::VarnodeData, std::string> el) {
-    VarnodeInfoFFI varnode = varnodeToFFI(std::get<0>(el));
-    rust::String name = std::get<1>(el);
-    return {varnode, name};
 }
 
 rust::Vec<RegisterInfoFFI> ContextFFI::getRegisters() const {

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <utility>
-#include "image_context.h"
+#include "sleigh_image.h"
 #include "jingle_sleigh/src/ffi/instruction.rs.h"
 #include "sleigh/loadimage.hh"
 
@@ -85,6 +85,6 @@ rust::Vec<RegisterInfoFFI> ContextFFI::getRegisters() const {
     return v;
 }
 
-std::unique_ptr<SleighImage> ContextFFI::makeImageContext(Image img) {
-    return std::unique_ptr<SleighImage>(new SleighImage(img, sleigh));
+std::unique_ptr<SleighImage> ContextFFI::makeImageContext(Image img) const {
+    return std::make_unique<SleighImage>(img, sleigh);
 }

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -3,50 +3,12 @@
 
 #include <memory>
 #include <utility>
+#include "image_context.h"
 #include "jingle_sleigh/src/ffi/instruction.rs.h"
 #include "sleigh/loadimage.hh"
 
 
-DummyLoadImage::DummyLoadImage() : ghidra::LoadImage("jingle") {
-    img = Image{};
-}
-
-DummyLoadImage::DummyLoadImage(Image image) : ghidra::LoadImage("jingle") {
-    img = std::move(image);
-}
-
-void DummyLoadImage::loadFill(ghidra::uint1 *ptr, ghidra::int4 size, const ghidra::Address &addr) {
-    size_t offset = addr.getOffset();
-    size_t bytes_written = 0;
-    for (const auto &section: img.sections) {
-        size_t start = section.base_address;
-        size_t end = start + section.data.size();
-        if (start <= offset && offset < end) {
-            size_t len = std::min((size_t) size, (size_t) end - (size_t) offset);
-            size_t start_idx = offset - start;
-            std::memcpy(ptr, &section.data[start_idx], len);
-            offset = offset + len;
-            bytes_written += len;
-        }
-    }
-    for (size_t i = offset; i < size; ++i) {
-        ptr[i] = 0;
-    }
-    if (bytes_written == 0) {
-        ghidra::ostringstream errmsg;
-        errmsg << "Unable to load " << std::dec << size << " bytes at " << addr.getShortcut();
-        addr.printRaw(errmsg);
-        throw ghidra::DataUnavailError(errmsg.str());
-    }
-}
-
-void DummyLoadImage::adjustVma(long adjust) {}
-
-std::string DummyLoadImage::getArchType() const {
-    return "placeholder";
-}
-
-ContextFFI::ContextFFI(rust::Str slaPath) {
+ContextFFI::ContextFFI(rust::Str slaPath): sleigh(&image, &c_db) {
     ghidra::AttributeId::initialize();
     ghidra::ElementId::initialize();
 
@@ -61,8 +23,8 @@ ContextFFI::ContextFFI(rust::Str slaPath) {
     ghidra::Document *doc = documentStorage.parseDocument(sleighfilename);
     ghidra::Element *root = doc->getRoot();
     documentStorage.registerTag(root);
-    sleigh = ghidra::Sleigh(&img, &c_db);
-    sleigh.initialize(documentStorage);
+    this->sleigh = ghidra::Sleigh(&img, &c_db);
+    this->sleigh.initialize(documentStorage);
 
 }
 
@@ -94,8 +56,8 @@ rust::Str ContextFFI::getRegisterName(VarnodeInfoFFI vn) const {
     return {name};
 }
 
-std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath, Image img) {
-    return std::make_unique<ContextFFI>(slaPath, std::move(img));
+std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath) {
+    return std::make_unique<ContextFFI>(slaPath);
 }
 
 VarnodeInfoFFI varnodeToFFI(ghidra::VarnodeData vn) {
@@ -124,5 +86,5 @@ rust::Vec<RegisterInfoFFI> ContextFFI::getRegisters() const {
 }
 
 std::unique_ptr<SleighImage> ContextFFI::makeImageContext(Image img) {
-    return std::unique_ptr<SleighImage>(sleigh, img);
+    return std::unique_ptr<SleighImage>(new SleighImage(img, sleigh));
 }

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -58,7 +58,7 @@ public:
 };
 
 
-ContextFFI::ContextFFI(rust::Str slaPath): sleigh(new DummyLoadImage(Image()), new ghidra::ContextInternal()) {
+ContextFFI::ContextFFI(rust::Str slaPath): sleigh(new DummyLoadImage(Image()), &c_db) {
     ghidra::AttributeId::initialize();
     ghidra::ElementId::initialize();
 
@@ -116,7 +116,7 @@ rust::Vec<RegisterInfoFFI> ContextFFI::getRegisters() const {
 }
 
 void ContextFFI::setImage(Image img) {
-    sleigh.reset(new DummyLoadImage(img), new ghidra::ContextInternal());
+    sleigh.reset(new DummyLoadImage(std::move(img)), &c_db);
 }
 
 InstructionFFI ContextFFI::get_one_instruction(uint64_t offset) const {

--- a/jingle_sleigh/src/ffi/cpp/context.h
+++ b/jingle_sleigh/src/ffi/cpp/context.h
@@ -9,6 +9,7 @@
 #include "sleigh/sleigh.hh"
 #include "jingle_sleigh/src/ffi/image.rs.h"
 #include "sleigh/loadimage.hh"
+#include "image_context.h"
 
 class DummyLoadImage : public ghidra::LoadImage {
     Image img;
@@ -27,18 +28,16 @@ public:
 
 
 class ContextFFI {
-    DummyLoadImage img;
-    ghidra::DocumentStorage documentStorage;
-    ghidra::ContextInternal contextDatabase;
-    std::unique_ptr<ghidra::Sleigh> sleigh;
+    ghidra::Sleigh sleigh;
+    ghidra::ContextInternal c_db;
+    DummyLoadImage image;
 public:
 
     explicit ContextFFI(rust::Str slaPath, Image img);
 
     void set_initial_context(rust::Str name, uint32_t val);
 
-    InstructionFFI get_one_instruction(uint64_t offset) const;
-
+    std::unique_ptr<SleighImage> makeImageContext(Image img);
 
     [[nodiscard]] std::shared_ptr<AddrSpaceHandle> getSpaceByIndex(ghidra::int4 idx) const;
 

--- a/jingle_sleigh/src/ffi/cpp/context.h
+++ b/jingle_sleigh/src/ffi/cpp/context.h
@@ -22,7 +22,9 @@ public:
 
     void set_initial_context(rust::Str name, uint32_t val);
 
-    std::unique_ptr<SleighImage> makeImageContext(Image img) const;
+    void setImage(Image img);
+
+    InstructionFFI get_one_instruction(uint64_t offset) const;
 
     [[nodiscard]] std::shared_ptr<AddrSpaceHandle> getSpaceByIndex(ghidra::int4 idx) const;
 

--- a/jingle_sleigh/src/ffi/cpp/context.h
+++ b/jingle_sleigh/src/ffi/cpp/context.h
@@ -10,22 +10,7 @@
 #include "jingle_sleigh/src/ffi/image.rs.h"
 #include "sleigh/loadimage.hh"
 #include "image_context.h"
-
-class DummyLoadImage : public ghidra::LoadImage {
-    Image img;
-public:
-    DummyLoadImage();
-
-    DummyLoadImage(Image img);
-
-    void loadFill(ghidra::uint1 *ptr, ghidra::int4 size, const ghidra::Address &addr) override;
-
-    std::string getArchType(void) const override;
-
-    void adjustVma(long adjust) override;
-
-};
-
+#include "dummy_load_image.h"
 
 class ContextFFI {
     ghidra::Sleigh sleigh;
@@ -33,7 +18,7 @@ class ContextFFI {
     DummyLoadImage image;
 public:
 
-    explicit ContextFFI(rust::Str slaPath, Image img);
+    explicit ContextFFI(rust::Str slaPath);
 
     void set_initial_context(rust::Str name, uint32_t val);
 
@@ -54,6 +39,6 @@ RegisterInfoFFI collectRegInfo(std::tuple<ghidra::VarnodeData*, std::string> el)
 
 VarnodeInfoFFI varnodeToFFI(ghidra::VarnodeData vn);
 
-std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath, Image img);
+std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath);
 
 #endif //JINGLE_SLEIGH_CONTEXT_H

--- a/jingle_sleigh/src/ffi/cpp/context.h
+++ b/jingle_sleigh/src/ffi/cpp/context.h
@@ -9,7 +9,7 @@
 #include "sleigh/sleigh.hh"
 #include "jingle_sleigh/src/ffi/image.rs.h"
 #include "sleigh/loadimage.hh"
-#include "image_context.h"
+#include "sleigh_image.h"
 #include "dummy_load_image.h"
 
 class ContextFFI {
@@ -22,7 +22,7 @@ public:
 
     void set_initial_context(rust::Str name, uint32_t val);
 
-    std::unique_ptr<SleighImage> makeImageContext(Image img);
+    std::unique_ptr<SleighImage> makeImageContext(Image img) const;
 
     [[nodiscard]] std::shared_ptr<AddrSpaceHandle> getSpaceByIndex(ghidra::int4 idx) const;
 

--- a/jingle_sleigh/src/ffi/cpp/dummy_load_image.cpp
+++ b/jingle_sleigh/src/ffi/cpp/dummy_load_image.cpp
@@ -22,7 +22,7 @@ void DummyLoadImage::loadFill(ghidra::uint1 *ptr, ghidra::int4 size, const ghidr
             bytes_written += len;
         }
     }
-    for (size_t i = offset; i < size; ++i) {
+    for (size_t i = bytes_written; i < size; ++i) {
         ptr[i] = 0;
     }
     if (bytes_written == 0) {

--- a/jingle_sleigh/src/ffi/cpp/dummy_load_image.cpp
+++ b/jingle_sleigh/src/ffi/cpp/dummy_load_image.cpp
@@ -1,0 +1,40 @@
+#include "dummy_load_image.h"
+
+DummyLoadImage::DummyLoadImage() : ghidra::LoadImage("jingle") {
+    img = Image{};
+}
+
+DummyLoadImage::DummyLoadImage(Image image) : ghidra::LoadImage("jingle") {
+    img = std::move(image);
+}
+
+void DummyLoadImage::loadFill(ghidra::uint1 *ptr, ghidra::int4 size, const ghidra::Address &addr) {
+    size_t offset = addr.getOffset();
+    size_t bytes_written = 0;
+    for (const auto &section: img.sections) {
+        size_t start = section.base_address;
+        size_t end = start + section.data.size();
+        if (start <= offset && offset < end) {
+            size_t len = std::min((size_t) size, (size_t) end - (size_t) offset);
+            size_t start_idx = offset - start;
+            std::memcpy(ptr, &section.data[start_idx], len);
+            offset = offset + len;
+            bytes_written += len;
+        }
+    }
+    for (size_t i = offset; i < size; ++i) {
+        ptr[i] = 0;
+    }
+    if (bytes_written == 0) {
+        ghidra::ostringstream errmsg;
+        errmsg << "Unable to load " << std::dec << size << " bytes at " << addr.getShortcut();
+        addr.printRaw(errmsg);
+        throw ghidra::DataUnavailError(errmsg.str());
+    }
+}
+
+void DummyLoadImage::adjustVma(long adjust) {}
+
+std::string DummyLoadImage::getArchType() const {
+    return "placeholder";
+}

--- a/jingle_sleigh/src/ffi/cpp/dummy_load_image.h
+++ b/jingle_sleigh/src/ffi/cpp/dummy_load_image.h
@@ -1,0 +1,25 @@
+
+#ifndef JINGLE_SLEIGH_DUMMY_LOAD_IMAGE_H
+#define JINGLE_SLEIGH_DUMMY_LOAD_IMAGE_H
+
+
+#include "jingle_sleigh/src/ffi/image.rs.h"
+#include "sleigh/loadimage.hh"
+
+class DummyLoadImage : public ghidra::LoadImage {
+    Image img;
+public:
+
+    DummyLoadImage();
+
+    DummyLoadImage(Image img);
+
+    void loadFill(ghidra::uint1 *ptr, ghidra::int4 size, const ghidra::Address &addr) override;
+
+    std::string getArchType(void) const override;
+
+    void adjustVma(long adjust) override;
+
+};
+
+#endif //JINGLE_SLEIGH_DUMMY_LOAD_IMAGE_H

--- a/jingle_sleigh/src/ffi/cpp/exception.h
+++ b/jingle_sleigh/src/ffi/cpp/exception.h
@@ -4,7 +4,6 @@
 
 #include "sleigh/error.hh"
 #include "sleigh/xml.hh"
-#include "sleigh/loadimage.hh"
 
 namespace rust {
     namespace behavior {
@@ -15,8 +14,6 @@ namespace rust {
         } catch (const ghidra::LowlevelError &e) {
             fail(e.explain);
         } catch (const ghidra::DecoderError &e) {
-            fail(e.explain);
-        } catch (const ghidra::DataUnavailError &e){
             fail(e.explain);
         } catch (const std::exception &e) {
             fail(e.what());

--- a/jingle_sleigh/src/ffi/cpp/exception.h
+++ b/jingle_sleigh/src/ffi/cpp/exception.h
@@ -4,6 +4,7 @@
 
 #include "sleigh/error.hh"
 #include "sleigh/xml.hh"
+#include "sleigh/loadimage.hh"
 
 namespace rust {
     namespace behavior {
@@ -14,6 +15,8 @@ namespace rust {
         } catch (const ghidra::LowlevelError &e) {
             fail(e.explain);
         } catch (const ghidra::DecoderError &e) {
+            fail(e.explain);
+        } catch (const ghidra::DataUnavailError &e){
             fail(e.explain);
         } catch (const std::exception &e) {
             fail(e.what());

--- a/jingle_sleigh/src/ffi/cpp/exception.h
+++ b/jingle_sleigh/src/ffi/cpp/exception.h
@@ -16,7 +16,7 @@ namespace rust {
         } catch (const ghidra::DecoderError &e) {
             fail(e.explain);
         } catch (const std::exception &e) {
-            fail(e.what());
+            throw e;
         }
     }
 }

--- a/jingle_sleigh/src/ffi/cpp/image_context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/image_context.cpp
@@ -2,7 +2,7 @@
 // Created by mark denhoed on 10/10/24.
 //
 #include "image_context.h"
-#include "context.h"
+#include "dummy_load_image.h"
 
 #include <utility>
 
@@ -53,24 +53,22 @@ public:
     }
 };
 
-SleighImage::SleighImage(Image img, ghidra::Sleigh sl) {
-    sl = sl;
-    image = DummyLoadImage(img);
+SleighImage::SleighImage(Image img, ghidra::Sleigh sl): sl(sl), image(DummyLoadImage(img)) {
     sl.reset(&image, &c_db);
 }
 
 
 
-std::shared_ptr<AddrSpaceHandle> ContextFFI::getSpaceByIndex(ghidra::int4 idx) const {
-    return std::make_shared<AddrSpaceHandle>(sleigh.getSpace(idx));
+std::shared_ptr<AddrSpaceHandle> SleighImage::getSpaceByIndex(ghidra::int4 idx) const {
+    return std::make_shared<AddrSpaceHandle>(sl.getSpace(idx));
 }
 
-ghidra::int4 ContextFFI::getNumSpaces() const {
-    return sleigh.numSpaces();
+ghidra::int4 SleighImage::getNumSpaces() const {
+    return sl.numSpaces();
 }
 
-VarnodeInfoFFI ContextFFI::getRegister(rust::Str name) const {
-    ghidra::VarnodeData vn = sleigh.getRegister(name.operator std::string());
+VarnodeInfoFFI SleighImage::getRegister(rust::Str name) const {
+    ghidra::VarnodeData vn = sl.getRegister(name.operator std::string());
     VarnodeInfoFFI info;
     info.space = std::make_unique<AddrSpaceHandle>(vn.space);
     info.size = vn.size;
@@ -78,11 +76,7 @@ VarnodeInfoFFI ContextFFI::getRegister(rust::Str name) const {
     return info;
 };
 
-rust::Str ContextFFI::getRegisterName(VarnodeInfoFFI vn) const {
-    std::string name = sleigh.getRegisterName(vn.space->getRaw(), vn.offset, vn.size);
+rust::Str SleighImage::getRegisterName(VarnodeInfoFFI vn) const {
+    std::string name = sl.getRegisterName(vn.space->getRaw(), vn.offset, vn.size);
     return {name};
-}
-
-std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath, Image img) {
-    return std::make_unique<ContextFFI>(slaPath, std::move(img));
 }

--- a/jingle_sleigh/src/ffi/cpp/image_context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/image_context.cpp
@@ -1,0 +1,88 @@
+//
+// Created by mark denhoed on 10/10/24.
+//
+#include "image_context.h"
+#include "context.h"
+
+#include <utility>
+
+class PcodeCacher : public ghidra::PcodeEmit {
+public:
+    rust::Vec<RawPcodeOp> ops;
+
+    PcodeCacher() = default;
+
+    void dump(const ghidra::Address &addr, ghidra::OpCode opc, ghidra::VarnodeData *outvar, ghidra::VarnodeData *vars,
+              ghidra::int4 isize) override {
+        RawPcodeOp op;
+        op.op = opc;
+        op.has_output = false;
+        if (outvar != nullptr && outvar->space != nullptr) {
+            op.has_output = true;
+            op.output.offset = outvar->offset;
+            op.output.size = outvar->size;
+            op.output.space = std::make_unique<AddrSpaceHandle>(AddrSpaceHandle(outvar->space));
+            outvar->space->getType();
+        }
+        op.inputs.reserve(isize);
+        for (int i = 0; i < isize; i++) {
+            VarnodeInfoFFI info;
+            info.space = std::make_unique<AddrSpaceHandle>(vars[i].space);
+            info.size = vars[i].size;
+            info.offset = vars[i].offset;
+            op.space = std::make_unique<AddrSpaceHandle>(addr.getSpace());
+            op.inputs.emplace_back(std::move(info));
+        }
+        ops.emplace_back(op);
+
+    }
+};
+
+class AssemblyCacher : public ghidra::AssemblyEmit {
+public:
+    rust::String mnem;
+    rust::String body;
+
+    AssemblyCacher() : mnem(""), body("") {
+
+    };
+
+    void dump(const ghidra::Address &addr, const std::string &mnem, const std::string &body) override {
+        this->mnem = mnem;
+        this->body = body;
+    }
+};
+
+SleighImage::SleighImage(Image img, ghidra::Sleigh sl) {
+    sl = sl;
+    image = DummyLoadImage(img);
+    sl.reset(&image, &c_db);
+}
+
+
+
+std::shared_ptr<AddrSpaceHandle> ContextFFI::getSpaceByIndex(ghidra::int4 idx) const {
+    return std::make_shared<AddrSpaceHandle>(sleigh.getSpace(idx));
+}
+
+ghidra::int4 ContextFFI::getNumSpaces() const {
+    return sleigh.numSpaces();
+}
+
+VarnodeInfoFFI ContextFFI::getRegister(rust::Str name) const {
+    ghidra::VarnodeData vn = sleigh.getRegister(name.operator std::string());
+    VarnodeInfoFFI info;
+    info.space = std::make_unique<AddrSpaceHandle>(vn.space);
+    info.size = vn.size;
+    info.offset = vn.offset;
+    return info;
+};
+
+rust::Str ContextFFI::getRegisterName(VarnodeInfoFFI vn) const {
+    std::string name = sleigh.getRegisterName(vn.space->getRaw(), vn.offset, vn.size);
+    return {name};
+}
+
+std::unique_ptr<ContextFFI> makeContext(rust::Str slaPath, Image img) {
+    return std::make_unique<ContextFFI>(slaPath, std::move(img));
+}

--- a/jingle_sleigh/src/ffi/cpp/image_context.h
+++ b/jingle_sleigh/src/ffi/cpp/image_context.h
@@ -1,0 +1,35 @@
+//
+// Created by toolCHAINZ on 10/10/24.
+//
+
+#ifndef JINGLE_SLEIGH_IMAGE_CONTEXT_H
+#define JINGLE_SLEIGH_IMAGE_CONTEXT_H
+
+#include "sleigh/sleigh.hh"
+#include "rust/cxx.h"
+#include "jingle_sleigh/src/ffi/image.rs.h"
+#include "context.h"
+
+class SleighImage{
+    ghidra::Sleigh sl;
+    ghidra::ContextInternal c_db;
+    DummyLoadImage image;
+
+public:
+    SleighImage(ghidra::Sleigh, Image);
+
+    InstructionFFI get_one_instruction(uint64_t offset) const;
+
+
+    [[nodiscard]] std::shared_ptr<AddrSpaceHandle> getSpaceByIndex(ghidra::int4 idx) const;
+
+    int getNumSpaces() const;
+
+    VarnodeInfoFFI getRegister(rust::Str name) const;
+
+    rust::Str getRegisterName(VarnodeInfoFFI name) const;
+
+    rust::Vec<RegisterInfoFFI> getRegisters() const;
+};
+
+#endif //JINGLE_SLEIGH_IMAGE_CONTEXT_H

--- a/jingle_sleigh/src/ffi/cpp/image_context.h
+++ b/jingle_sleigh/src/ffi/cpp/image_context.h
@@ -5,10 +5,12 @@
 #ifndef JINGLE_SLEIGH_IMAGE_CONTEXT_H
 #define JINGLE_SLEIGH_IMAGE_CONTEXT_H
 
+#include "addrspace_handle.h"
+#include "jingle_sleigh/src/ffi/instruction.rs.h"
 #include "sleigh/sleigh.hh"
 #include "rust/cxx.h"
 #include "jingle_sleigh/src/ffi/image.rs.h"
-#include "context.h"
+#include "dummy_load_image.h"
 
 class SleighImage{
     ghidra::Sleigh sl;
@@ -16,10 +18,9 @@ class SleighImage{
     DummyLoadImage image;
 
 public:
-    SleighImage(ghidra::Sleigh, Image);
+    SleighImage(Image img, ghidra::Sleigh& sl);
 
     InstructionFFI get_one_instruction(uint64_t offset) const;
-
 
     [[nodiscard]] std::shared_ptr<AddrSpaceHandle> getSpaceByIndex(ghidra::int4 idx) const;
 

--- a/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
+++ b/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
@@ -54,8 +54,8 @@ public:
     }
 };
 
-SleighImage::SleighImage(Image img, ghidra::Sleigh sl): sl(sl) {
-    sl.reset(new DummyLoadImage(img), new ghidra::ContextInternal());
+SleighImage::SleighImage(Image img, ghidra::Sleigh sl): sl(ghidra::Sleigh(sl)) {
+    this->sl.reset(new DummyLoadImage(img), new ghidra::ContextInternal());
 }
 
 

--- a/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
+++ b/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
@@ -7,58 +7,10 @@
 #include "sleigh/sleigh.hh"
 #include <utility>
 
-class PcodeCacher : public ghidra::PcodeEmit {
-public:
-    rust::Vec<RawPcodeOp> ops;
-
-    PcodeCacher() = default;
-
-    void dump(const ghidra::Address &addr, ghidra::OpCode opc, ghidra::VarnodeData *outvar, ghidra::VarnodeData *vars,
-              ghidra::int4 isize) override {
-        RawPcodeOp op;
-        op.op = opc;
-        op.has_output = false;
-        if (outvar != nullptr && outvar->space != nullptr) {
-            op.has_output = true;
-            op.output.offset = outvar->offset;
-            op.output.size = outvar->size;
-            op.output.space = std::make_unique<AddrSpaceHandle>(AddrSpaceHandle(outvar->space));
-            outvar->space->getType();
-        }
-        op.inputs.reserve(isize);
-        for (int i = 0; i < isize; i++) {
-            VarnodeInfoFFI info;
-            info.space = std::make_unique<AddrSpaceHandle>(vars[i].space);
-            info.size = vars[i].size;
-            info.offset = vars[i].offset;
-            op.space = std::make_unique<AddrSpaceHandle>(addr.getSpace());
-            op.inputs.emplace_back(std::move(info));
-        }
-        ops.emplace_back(op);
-
-    }
-};
-
-class AssemblyCacher : public ghidra::AssemblyEmit {
-public:
-    rust::String mnem;
-    rust::String body;
-
-    AssemblyCacher() : mnem(""), body("") {
-
-    };
-
-    void dump(const ghidra::Address &addr, const std::string &mnem, const std::string &body) override {
-        this->mnem = mnem;
-        this->body = body;
-    }
-};
 
 SleighImage::SleighImage(Image img, ghidra::Sleigh sl): sl(ghidra::Sleigh(sl)) {
     this->sl.reset(new DummyLoadImage(img), new ghidra::ContextInternal());
 }
-
-
 
 std::shared_ptr<AddrSpaceHandle> SleighImage::getSpaceByIndex(ghidra::int4 idx) const {
     return std::make_shared<AddrSpaceHandle>(sl.getSpace(idx));
@@ -81,25 +33,6 @@ rust::Str SleighImage::getRegisterName(VarnodeInfoFFI vn) const {
     std::string name = sl.getRegisterName(vn.space->getRaw(), vn.offset, vn.size);
     return {name};
 }
-
-InstructionFFI SleighImage::get_one_instruction(uint64_t offset) const {
-    PcodeCacher pcode;
-    AssemblyCacher assembly;
-    ghidra::Address a = ghidra::Address(sl.getDefaultCodeSpace(), offset);
-    sl.printAssembly(assembly, a);
-    sl.oneInstruction(pcode, a);
-    size_t length = sl.instructionLength(a);
-    InstructionFFI i;
-    Disassembly d;
-    i.ops = std::move(pcode.ops);
-    d.args = std::move(assembly.body);
-    d.mnemonic = std::move(assembly.mnem);
-    i.disassembly = std::move(d);
-    i.address = offset;
-    i.length = length;
-    return i;
-}
-
 
 rust::Vec<RegisterInfoFFI> SleighImage::getRegisters() const {
     std::map<ghidra::VarnodeData, std::string> reglist;

--- a/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
+++ b/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
@@ -4,7 +4,7 @@
 #include "sleigh_image.h"
 #include "dummy_load_image.h"
 #include "varnode_translation.h"
-
+#include "sleigh/sleigh.hh"
 #include <utility>
 
 class PcodeCacher : public ghidra::PcodeEmit {
@@ -54,8 +54,8 @@ public:
     }
 };
 
-SleighImage::SleighImage(Image img, ghidra::Sleigh sl): sl(sl), image(DummyLoadImage(img)) {
-    sl.reset(&image, &c_db);
+SleighImage::SleighImage(Image img, ghidra::Sleigh sl): sl(sl) {
+    sl.reset(new DummyLoadImage(img), new ghidra::ContextInternal());
 }
 
 

--- a/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
+++ b/jingle_sleigh/src/ffi/cpp/sleigh_image.cpp
@@ -1,7 +1,7 @@
 //
 // Created by mark denhoed on 10/10/24.
 //
-#include "image_context.h"
+#include "sleigh_image.h"
 #include "dummy_load_image.h"
 
 #include <utility>

--- a/jingle_sleigh/src/ffi/cpp/sleigh_image.h
+++ b/jingle_sleigh/src/ffi/cpp/sleigh_image.h
@@ -2,8 +2,8 @@
 // Created by toolCHAINZ on 10/10/24.
 //
 
-#ifndef JINGLE_SLEIGH_IMAGE_CONTEXT_H
-#define JINGLE_SLEIGH_IMAGE_CONTEXT_H
+#ifndef JINGLE_SLEIGH_SLEIGH_IMAGE_H
+#define JINGLE_SLEIGH_SLEIGH_IMAGE_H
 
 #include "addrspace_handle.h"
 #include "jingle_sleigh/src/ffi/instruction.rs.h"
@@ -18,7 +18,7 @@ class SleighImage{
     DummyLoadImage image;
 
 public:
-    SleighImage(Image img, ghidra::Sleigh& sl);
+    SleighImage(Image img, ghidra::Sleigh sl);
 
     InstructionFFI get_one_instruction(uint64_t offset) const;
 
@@ -33,4 +33,4 @@ public:
     rust::Vec<RegisterInfoFFI> getRegisters() const;
 };
 
-#endif //JINGLE_SLEIGH_IMAGE_CONTEXT_H
+#endif //JINGLE_SLEIGH_SLEIGH_IMAGE_H

--- a/jingle_sleigh/src/ffi/cpp/sleigh_image.h
+++ b/jingle_sleigh/src/ffi/cpp/sleigh_image.h
@@ -14,8 +14,6 @@
 
 class SleighImage{
     ghidra::Sleigh sl;
-    ghidra::ContextInternal c_db;
-    DummyLoadImage image;
 
 public:
     SleighImage(Image img, ghidra::Sleigh sl);

--- a/jingle_sleigh/src/ffi/cpp/varnode_translation.cpp
+++ b/jingle_sleigh/src/ffi/cpp/varnode_translation.cpp
@@ -1,0 +1,16 @@
+#include "varnode_translation.h"
+#include "addrspace_handle.h"
+
+VarnodeInfoFFI varnodeToFFI(ghidra::VarnodeData vn) {
+    VarnodeInfoFFI info;
+    info.space = std::make_unique<AddrSpaceHandle>(vn.space);
+    info.size = vn.size;
+    info.offset = vn.offset;
+    return info;
+}
+
+RegisterInfoFFI collectRegInfo(std::tuple<ghidra::VarnodeData, std::string> el) {
+    VarnodeInfoFFI varnode = varnodeToFFI(std::get<0>(el));
+    rust::String name = std::get<1>(el);
+    return {varnode, name};
+}

--- a/jingle_sleigh/src/ffi/cpp/varnode_translation.h
+++ b/jingle_sleigh/src/ffi/cpp/varnode_translation.h
@@ -1,0 +1,13 @@
+
+#ifndef JINGLE_SLEIGH_VARNODE_TRANSLATION_H
+#define JINGLE_SLEIGH_VARNODE_TRANSLATION_H
+#include "sleigh/types.h"
+#include "sleigh/translate.hh"
+#include "jingle_sleigh/src/ffi/instruction.rs.h"
+
+
+VarnodeInfoFFI varnodeToFFI(ghidra::VarnodeData vn);
+
+RegisterInfoFFI collectRegInfo(std::tuple<ghidra::VarnodeData, std::string> el);
+
+#endif //JINGLE_SLEIGH_VARNODE_TRANSLATION_H

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -11,7 +11,7 @@ use libz_sys::inflate;
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{Image, SleighContextBuilder};
+    use crate::context::{SleighContextBuilder};
     use crate::tests::SLEIGH_ARCH;
 
     #[test]

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod context_ffi;
 pub(crate) mod image;
 pub(crate) mod instruction;
 pub(crate) mod opcode;
-pub(crate) mod sleigh_image;
 
 // Need to pull this in somewhere so that libz symbols are available
 // for the `sleigh` CPP code at link-time.
@@ -20,11 +19,9 @@ mod tests {
         let builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
-        let sleigh = builder
-            .build("x86:LE:64:default")
-            .unwrap();
-        let bin_image = sleigh.load_image(bytes.as_slice()).unwrap();
-        let _lib = bin_image.instruction_at(0).unwrap();
+        let mut sleigh = builder.build("x86:LE:64:default").unwrap();
+        sleigh.set_image(bytes.as_slice()).unwrap();
+        sleigh.instruction_at(0).unwrap();
     }
     #[test]
     fn test_callother_decode2() {
@@ -32,10 +29,8 @@ mod tests {
         let builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
-        let sleigh = builder
-            .build("x86:LE:64:default")
-            .unwrap();
-        let bin_image = sleigh.load_image(bytes.as_slice()).unwrap();
-        let _lib = bin_image.instruction_at(0).unwrap();
+        let mut sleigh = builder.build("x86:LE:64:default").unwrap();
+        sleigh.set_image(bytes.as_slice()).unwrap();
+        sleigh.instruction_at(0).unwrap();
     }
 }

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -21,7 +21,7 @@ mod tests {
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
         let mut sleigh = builder.build("x86:LE:64:default").unwrap();
-        sleigh.set_image(bytes.as_slice()).unwrap();
+        let sleigh = sleigh.set_image(bytes.as_slice()).unwrap();
         sleigh.instruction_at(0).unwrap();
     }
     #[test]
@@ -31,7 +31,7 @@ mod tests {
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
         let mut sleigh = builder.build("x86:LE:64:default").unwrap();
-        sleigh.set_image(bytes.as_slice()).unwrap();
+        let sleigh = sleigh.set_image(bytes.as_slice()).unwrap();
         sleigh.instruction_at(0).unwrap();
     }
 
@@ -44,7 +44,7 @@ mod tests {
         let mut sleigh = ctx_builder
             .build(SLEIGH_ARCH)
             .unwrap();
-        sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let mut sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
         let instr1 = sleigh.instruction_at(0);
         sleigh.set_image(nops.as_slice()).unwrap();
         let instr2 = sleigh.instruction_at(0);

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -11,7 +11,7 @@ use libz_sys::inflate;
 
 #[cfg(test)]
 mod tests {
-    use crate::context::{SleighContextBuilder};
+    use crate::context::SleighContextBuilder;
     use crate::tests::SLEIGH_ARCH;
 
     #[test]
@@ -36,14 +36,12 @@ mod tests {
     }
 
     #[test]
-    fn test_two_images(){
+    fn test_two_images() {
         let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
         let nops: [u8; 9] = [0x90, 0x90, 0x90, 0x90, 0x0f, 0x05, 0x0f, 0x05, 0x0f];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let mut sleigh = ctx_builder
-            .build(SLEIGH_ARCH)
-            .unwrap();
+        let mut sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
         let mut sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
         let instr1 = sleigh.instruction_at(0);
         sleigh.set_image(nops.as_slice()).unwrap();

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -20,11 +20,11 @@ mod tests {
         let builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
-        let bin_sleigh = builder
-            .set_image(Image::from(bytes.as_slice()))
+        let sleigh = builder
             .build("x86:LE:64:default")
             .unwrap();
-        let _lib = bin_sleigh.read(0, 1).next().unwrap();
+        let bin_image = sleigh.load_image(bytes.as_slice()).unwrap();
+        let _lib = bin_image.instruction_at(0).unwrap();
     }
     #[test]
     fn test_callother_decode2() {
@@ -32,10 +32,10 @@ mod tests {
         let builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
-        let bin_sleigh = builder
-            .set_image(Image::from(bytes.as_slice()))
+        let sleigh = builder
             .build("x86:LE:64:default")
             .unwrap();
-        let _lib = bin_sleigh.read(0, 1).next().unwrap();
+        let bin_image = sleigh.load_image(bytes.as_slice()).unwrap();
+        let _lib = bin_image.instruction_at(0).unwrap();
     }
 }

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod context_ffi;
 pub(crate) mod image;
 pub(crate) mod instruction;
 pub(crate) mod opcode;
+pub(crate) mod sleigh_image;
 
 // Need to pull this in somewhere so that libz symbols are available
 // for the `sleigh` CPP code at link-time.

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -38,7 +38,7 @@ mod tests {
     #[test]
     fn test_two_images(){
         let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
-        let nops: [u8; 4] = [0x90, 0x90, 0x90, 0x90];
+        let nops: [u8; 9] = [0x90, 0x90, 0x90, 0x90, 0x0f, 0x05, 0x0f, 0x05, 0x0f];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
         let mut sleigh = ctx_builder
@@ -50,5 +50,10 @@ mod tests {
         let instr2 = sleigh.instruction_at(0);
         assert_ne!(instr1, instr2);
         assert_ne!(instr1, None);
+        let instr2 = sleigh.instruction_at(4);
+        assert_ne!(instr1, instr2);
+        assert_ne!(instr2, None);
+        let instr3 = sleigh.instruction_at(8);
+        assert_eq!(instr3, None);
     }
 }

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -20,8 +20,8 @@ mod tests {
         let builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
-        let mut sleigh = builder.build("x86:LE:64:default").unwrap();
-        let sleigh = sleigh.set_image(bytes.as_slice()).unwrap();
+        let sleigh = builder.build("x86:LE:64:default").unwrap();
+        let sleigh = sleigh.initialize_with_image(bytes.as_slice()).unwrap();
         sleigh.instruction_at(0).unwrap();
     }
     #[test]
@@ -30,8 +30,8 @@ mod tests {
         let builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
 
-        let mut sleigh = builder.build("x86:LE:64:default").unwrap();
-        let sleigh = sleigh.set_image(bytes.as_slice()).unwrap();
+        let sleigh = builder.build("x86:LE:64:default").unwrap();
+        let sleigh = sleigh.initialize_with_image(bytes.as_slice()).unwrap();
         sleigh.instruction_at(0).unwrap();
     }
 
@@ -41,8 +41,8 @@ mod tests {
         let nops: [u8; 9] = [0x90, 0x90, 0x90, 0x90, 0x0f, 0x05, 0x0f, 0x05, 0x0f];
         let ctx_builder =
             SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
-        let mut sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
-        let mut sleigh = sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        let mut sleigh = sleigh.initialize_with_image(mov_eax_0.as_slice()).unwrap();
         let instr1 = sleigh.instruction_at(0);
         sleigh.set_image(nops.as_slice()).unwrap();
         let instr2 = sleigh.instruction_at(0);

--- a/jingle_sleigh/src/ffi/mod.rs
+++ b/jingle_sleigh/src/ffi/mod.rs
@@ -12,6 +12,7 @@ use libz_sys::inflate;
 #[cfg(test)]
 mod tests {
     use crate::context::{Image, SleighContextBuilder};
+    use crate::tests::SLEIGH_ARCH;
 
     #[test]
     fn test_callother_decode() {
@@ -32,5 +33,22 @@ mod tests {
         let mut sleigh = builder.build("x86:LE:64:default").unwrap();
         sleigh.set_image(bytes.as_slice()).unwrap();
         sleigh.instruction_at(0).unwrap();
+    }
+
+    #[test]
+    fn test_two_images(){
+        let mov_eax_0: [u8; 4] = [0x0f, 0x05, 0x0f, 0x05];
+        let nops: [u8; 4] = [0x90, 0x90, 0x90, 0x90];
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let mut sleigh = ctx_builder
+            .build(SLEIGH_ARCH)
+            .unwrap();
+        sleigh.set_image(mov_eax_0.as_slice()).unwrap();
+        let instr1 = sleigh.instruction_at(0);
+        sleigh.set_image(nops.as_slice()).unwrap();
+        let instr2 = sleigh.instruction_at(0);
+        assert_ne!(instr1, instr2);
+        assert_ne!(instr1, None);
     }
 }

--- a/jingle_sleigh/src/ffi/sleigh_image.rs
+++ b/jingle_sleigh/src/ffi/sleigh_image.rs
@@ -1,0 +1,31 @@
+#[cxx::bridge]
+pub(crate) mod bridge {
+    unsafe extern "C++" {
+        type Image = crate::context::Image;
+        type InstructionFFI = crate::ffi::instruction::bridge::InstructionFFI;
+
+        type VarnodeInfoFFI = crate::ffi::instruction::bridge::VarnodeInfoFFI;
+
+        type AddrSpaceHandle = crate::ffi::addrspace::bridge::AddrSpaceHandle;
+
+        type RegisterInfoFFI = crate::ffi::instruction::bridge::RegisterInfoFFI;
+    }
+
+    unsafe extern "C++" {
+        include!("jingle_sleigh/src/ffi/cpp/sleigh_image.h");
+
+        pub(crate) type SleighImage;
+
+        pub(crate) fn getSpaceByIndex(&self, idx: i32) -> SharedPtr<AddrSpaceHandle>;
+        pub(crate) fn getNumSpaces(&self) -> i32;
+
+        pub(crate) fn getRegister(&self, name: &str) -> Result<VarnodeInfoFFI>;
+        pub(crate) fn getRegisterName(&self, name: VarnodeInfoFFI) -> Result<&str>;
+
+        pub(crate) fn getRegisters(&self) -> Vec<RegisterInfoFFI>;
+
+        pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
+    }
+
+    impl UniquePtr<SleighImage> {}
+}

--- a/jingle_sleigh/src/pcode/mod.rs
+++ b/jingle_sleigh/src/pcode/mod.rs
@@ -399,78 +399,220 @@ impl PcodeOperation {
 
     pub fn inputs(&self) -> Vec<GeneralizedVarNode> {
         match self {
-            Copy { input, .. } => {vec![input.into()]}
-            Load { input, .. } => {vec![input.into(), input.pointer_location.clone().into()]}
-            Store { input, output } => {vec![input.into(), output.pointer_location.clone().into()]}
-            Branch { input, .. } => {vec![input.into()]}
-            CBranch { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            BranchInd { input, .. } => {vec![input.into()]}
-            Call { input, .. } => {vec![input.into()]}
-            CallInd { input, .. } => {vec![input.into()]}
-            CallOther { inputs, .. } => {inputs.iter().map(|i|i.into()).collect()}
-            Return { input, .. } => {vec![input.into()]}
-            IntEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntNotEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedLess  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedLessEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntLess  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntLessEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSExt { input, .. } => {vec![input.into()]}
-            IntZExt { input, .. } => {vec![input.into()]}
-            IntAdd  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSub  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntCarry  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedCarry  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedBorrow  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            Int2Comp { input, .. } => {vec![input.into()]}
-            IntNegate { input, .. } => {vec![input.into()]}
-            IntXor  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntAnd  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntOr  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntLeftShift  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntRightShift  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedRightShift  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntMult  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntDiv  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedDiv  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntRem  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            IntSignedRem  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            BoolNegate  { input, .. } => {vec![input.into()]}
-            BoolXor  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            BoolAnd  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            BoolOr  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatNotEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatLess  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatLessEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatNaN { input, .. } => {vec![input.into()]}
-            FloatAdd  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatDiv  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatMult  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatSub  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            FloatNeg { input, .. } => {vec![input.into()]}
-            FloatAbs { input, .. } => {vec![input.into()]}
-            FloatSqrt { input, .. } => {vec![input.into()]}
-            FloatIntToFloat { input, .. } => {vec![input.into()]}
-            FloatFloatToFloat { input, .. } => {vec![input.into()]}
-            FloatTrunc { input, .. } => {vec![input.into()]}
-            FloatCeil { input, .. } => {vec![input.into()]}
-            FloatFloor { input, .. } => {vec![input.into()]}
-            FloatRound { input, .. } => {vec![input.into()]}
-            MultiEqual  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            Indirect  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            Piece  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            SubPiece  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            Cast { input, .. } => {vec![input.into()]}
-            PtrAdd  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            PtrSub  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            SegmentOp  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            CPoolRef  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            New { input, .. } => {vec![input.into()]}
-            Insert  { input0, input1, .. } => {vec![input0.into(), input1.into()]}
-            Extract  { input0, .. } => {vec![input0.into()]}
-            PopCount { input, .. } => {vec![input.into()]}
-            LzCount { input, .. } => {vec![input.into()]}
+            Copy { input, .. } => {
+                vec![input.into()]
+            }
+            Load { input, .. } => {
+                vec![input.into(), input.pointer_location.clone().into()]
+            }
+            Store { input, output } => {
+                vec![input.into(), output.pointer_location.clone().into()]
+            }
+            Branch { input, .. } => {
+                vec![input.into()]
+            }
+            CBranch { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            BranchInd { input, .. } => {
+                vec![input.into()]
+            }
+            Call { input, .. } => {
+                vec![input.into()]
+            }
+            CallInd { input, .. } => {
+                vec![input.into()]
+            }
+            CallOther { inputs, .. } => inputs.iter().map(|i| i.into()).collect(),
+            Return { input, .. } => {
+                vec![input.into()]
+            }
+            IntEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntNotEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedLess { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedLessEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntLess { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntLessEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSExt { input, .. } => {
+                vec![input.into()]
+            }
+            IntZExt { input, .. } => {
+                vec![input.into()]
+            }
+            IntAdd { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSub { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntCarry { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedCarry { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedBorrow { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            Int2Comp { input, .. } => {
+                vec![input.into()]
+            }
+            IntNegate { input, .. } => {
+                vec![input.into()]
+            }
+            IntXor { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntAnd { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntOr { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntLeftShift { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntRightShift { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedRightShift { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntMult { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntDiv { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedDiv { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntRem { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            IntSignedRem { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            BoolNegate { input, .. } => {
+                vec![input.into()]
+            }
+            BoolXor { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            BoolAnd { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            BoolOr { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatNotEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatLess { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatLessEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatNaN { input, .. } => {
+                vec![input.into()]
+            }
+            FloatAdd { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatDiv { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatMult { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatSub { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            FloatNeg { input, .. } => {
+                vec![input.into()]
+            }
+            FloatAbs { input, .. } => {
+                vec![input.into()]
+            }
+            FloatSqrt { input, .. } => {
+                vec![input.into()]
+            }
+            FloatIntToFloat { input, .. } => {
+                vec![input.into()]
+            }
+            FloatFloatToFloat { input, .. } => {
+                vec![input.into()]
+            }
+            FloatTrunc { input, .. } => {
+                vec![input.into()]
+            }
+            FloatCeil { input, .. } => {
+                vec![input.into()]
+            }
+            FloatFloor { input, .. } => {
+                vec![input.into()]
+            }
+            FloatRound { input, .. } => {
+                vec![input.into()]
+            }
+            MultiEqual { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            Indirect { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            Piece { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            SubPiece { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            Cast { input, .. } => {
+                vec![input.into()]
+            }
+            PtrAdd { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            PtrSub { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            SegmentOp { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            CPoolRef { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            New { input, .. } => {
+                vec![input.into()]
+            }
+            Insert { input0, input1, .. } => {
+                vec![input0.into(), input1.into()]
+            }
+            Extract { input0, .. } => {
+                vec![input0.into()]
+            }
+            PopCount { input, .. } => {
+                vec![input.into()]
+            }
+            LzCount { input, .. } => {
+                vec![input.into()]
+            }
         }
     }
     pub fn output(&self) -> Option<GeneralizedVarNode> {


### PR DESCRIPTION
Several changes to the sleigh bindings:

* Sleigh no longer requires an image to construct a sleigh context.
* Now supports reinitializing the sleigh context with a new image. This is MUCH faster than making a new sleigh context as the `.sla` definition is re-used.
* Initializing sleigh with a new image now requires `T: Into<Image> + Clone` rather than `Image`, making consumer code look much cleaner.
* Re-implemented `get_register` and friends to avoid some out-of-bounds reads over in C++ land.
* Fixed a few bugs that combined to allow sleigh to return instructions that overran the bounds of the provided image.
* Bumps ghidra/sleigh to 11.2