### PR TITLE
Context Refactor

### DIFF
--- a/jingle/src/context.rs
+++ b/jingle/src/context.rs
@@ -1,26 +1,41 @@
+use std::ops::Deref;
+use std::rc::Rc;
 use crate::modeling::State;
-use jingle_sleigh::{SpaceInfo, SpaceManager};
+use jingle_sleigh::{RegisterManager, SpaceInfo, SpaceManager, VarNode};
 use z3::Context;
 
 #[derive(Clone, Debug)]
-pub struct JingleContext<'ctx> {
+pub struct JingleContextInternal<'ctx> {
     pub z3: &'ctx Context,
     spaces: Vec<SpaceInfo>,
     default_code_space_index: usize,
+    registers: Vec<(VarNode, String)>,
 }
 
+#[derive(Clone, Debug)]
+pub struct JingleContext<'ctx>(Rc<JingleContextInternal<'ctx>>);
+
+
+impl<'ctx> Deref for JingleContext<'ctx>{
+    type Target = JingleContextInternal<'ctx>;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
 impl<'ctx> JingleContext<'ctx> {
-    pub fn new<S: SpaceManager>(z3: &'ctx Context, r: &S) -> Self {
+    pub fn new<S: RegisterManager>(z3: &'ctx Context, r: &S) -> Self {
         let spaces = r.get_all_space_info().to_vec();
         let default_code_space_index = r.get_code_space_idx();
-        Self {
+        Self(Rc::new(JingleContextInternal {
             z3,
             spaces,
             default_code_space_index,
-        }
+            registers: r.get_registers(),
+        }))
     }
     pub fn fresh_state(&self) -> State<'ctx> {
-        State::new(self.z3, self)
+        State::new(self)
     }
 }
 
@@ -35,5 +50,20 @@ impl<'ctx> SpaceManager for JingleContext<'ctx> {
 
     fn get_code_space_idx(&self) -> usize {
         self.default_code_space_index
+    }
+}
+
+
+impl<'ctx> RegisterManager for JingleContext<'ctx> {
+    fn get_register(&self, name: &str) -> Option<VarNode> {
+        self.registers.iter().find_map(|i| i.1.eq(name).then_some(i.0.clone()))
+    }
+
+    fn get_register_name(&self, location: &VarNode) -> Option<&str> {
+        self.registers.iter().find_map(|i| i.0.eq(location).then_some(i.1.as_str()))
+    }
+
+    fn get_registers(&self) -> Vec<(VarNode, String)> {
+        self.registers.clone()
     }
 }

--- a/jingle/src/context.rs
+++ b/jingle/src/context.rs
@@ -1,7 +1,7 @@
-use std::ops::Deref;
-use std::rc::Rc;
 use crate::modeling::State;
 use jingle_sleigh::{RegisterManager, SpaceInfo, SpaceManager, VarNode};
+use std::ops::Deref;
+use std::rc::Rc;
 use z3::Context;
 
 #[derive(Clone, Debug)]
@@ -15,8 +15,7 @@ pub struct JingleContextInternal<'ctx> {
 #[derive(Clone, Debug)]
 pub struct JingleContext<'ctx>(Rc<JingleContextInternal<'ctx>>);
 
-
-impl<'ctx> Deref for JingleContext<'ctx>{
+impl<'ctx> Deref for JingleContext<'ctx> {
     type Target = JingleContextInternal<'ctx>;
 
     fn deref(&self) -> &Self::Target {
@@ -53,14 +52,17 @@ impl<'ctx> SpaceManager for JingleContext<'ctx> {
     }
 }
 
-
 impl<'ctx> RegisterManager for JingleContext<'ctx> {
     fn get_register(&self, name: &str) -> Option<VarNode> {
-        self.registers.iter().find_map(|i| i.1.eq(name).then_some(i.0.clone()))
+        self.registers
+            .iter()
+            .find_map(|i| i.1.eq(name).then_some(i.0.clone()))
     }
 
     fn get_register_name(&self, location: &VarNode) -> Option<&str> {
-        self.registers.iter().find_map(|i| i.0.eq(location).then_some(i.1.as_str()))
+        self.registers
+            .iter()
+            .find_map(|i| i.0.eq(location).then_some(i.1.as_str()))
     }
 
     fn get_registers(&self) -> Vec<(VarNode, String)> {

--- a/jingle/src/lib.rs
+++ b/jingle/src/lib.rs
@@ -9,3 +9,9 @@ pub use jingle_sleigh as sleigh;
 pub use context::JingleContext;
 pub use error::JingleError;
 pub use translator::SleighTranslator;
+
+#[cfg(test)]
+mod tests{
+    pub(crate) const SLEIGH_ARCH: &str = "x86:LE:64:default";
+
+}

--- a/jingle/src/lib.rs
+++ b/jingle/src/lib.rs
@@ -11,7 +11,6 @@ pub use error::JingleError;
 pub use translator::SleighTranslator;
 
 #[cfg(test)]
-mod tests{
+mod tests {
     pub(crate) const SLEIGH_ARCH: &str = "x86:LE:64:default";
-
 }

--- a/jingle/src/main.rs
+++ b/jingle/src/main.rs
@@ -174,7 +174,7 @@ fn model(config: &JingleConfig, architecture: String, hex_bytes: String) {
     });
 
     let jingle_ctx = JingleContext::new(&z3, &sleigh);
-    let block = ModeledBlock::read(&z3, &sleigh, instrs.into_iter()).unwrap();
+    let block = ModeledBlock::read(&jingle_ctx, instrs.into_iter()).unwrap();
     let final_state = jingle_ctx.fresh_state();
     solver.assert(&final_state._eq(block.get_final_state()).unwrap().simplify());
     println!("{}", solver.to_smt2())

--- a/jingle/src/modeling/block.rs
+++ b/jingle/src/modeling/block.rs
@@ -5,17 +5,18 @@ use crate::modeling::state::State;
 use crate::modeling::{ModelingContext, TranslationContext};
 use crate::varnode::ResolvedVarnode;
 use crate::JingleError::EmptyBlock;
-use jingle_sleigh::Instruction;
+use jingle_sleigh::{Instruction, RegisterManager, VarNode};
 use jingle_sleigh::PcodeOperation;
 use jingle_sleigh::{SpaceInfo, SpaceManager};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use z3::Context;
+use crate::JingleContext;
 
 /// A `jingle` model of a basic block
 #[derive(Debug, Clone)]
 pub struct ModeledBlock<'ctx> {
-    z3: &'ctx Context,
+    jingle: JingleContext<'ctx>,
     pub instructions: Vec<Instruction>,
     state: State<'ctx>,
     original_state: State<'ctx>,
@@ -36,11 +37,11 @@ impl<'ctx> Display for ModeledBlock<'ctx> {
 impl<'ctx, T: ModelingContext<'ctx>> TryFrom<&'ctx [T]> for ModeledBlock<'ctx> {
     type Error = JingleError;
     fn try_from(vec: &'ctx [T]) -> Result<Self, Self::Error> {
-        let z3 = vec.first().ok_or(EmptyBlock)?.get_z3();
-        let original_state = State::new(z3, vec[0].get_original_state());
+        let jingle = vec.first().ok_or(EmptyBlock)?.get_jingle();
+        let original_state = State::new(jingle);
         let state = original_state.clone();
         let mut new_block: Self = Self {
-            z3,
+            jingle: jingle.clone(),
             instructions: Default::default(),
             state,
             original_state,
@@ -61,12 +62,11 @@ impl<'ctx, T: ModelingContext<'ctx>> TryFrom<&'ctx [T]> for ModeledBlock<'ctx> {
 }
 
 impl<'ctx> ModeledBlock<'ctx> {
-    pub fn read<T: Iterator<Item = Instruction>, S: SpaceManager>(
-        z3: &'ctx Context,
-        space_manager: &S,
+    pub fn read<T: Iterator<Item=Instruction>>(
+        jingle: &JingleContext<'ctx>,
         instr_iter: T,
     ) -> Result<Self, JingleError> {
-        let original_state = State::new(z3, space_manager);
+        let original_state = State::new(jingle);
         let state = original_state.clone();
 
         let mut block_terminated = false;
@@ -95,7 +95,7 @@ impl<'ctx> ModeledBlock<'ctx> {
         );
 
         let mut model = Self {
-            z3,
+            jingle: jingle.clone(),
             instructions,
             state,
             original_state,
@@ -110,7 +110,7 @@ impl<'ctx> ModeledBlock<'ctx> {
     }
 
     pub fn fresh(&self) -> Result<Self, JingleError> {
-        ModeledBlock::read(self.z3, self, self.instructions.clone().into_iter())
+        ModeledBlock::read(&self.jingle, self.instructions.clone().into_iter())
     }
 
     pub fn get_first_address(&self) -> u64 {
@@ -137,8 +137,8 @@ impl<'ctx> SpaceManager for ModeledBlock<'ctx> {
 }
 
 impl<'ctx> ModelingContext<'ctx> for ModeledBlock<'ctx> {
-    fn get_z3(&self) -> &'ctx Context {
-        self.z3
+    fn get_jingle(&self) -> &JingleContext<'ctx> {
+        &self.jingle
     }
 
     fn get_address(&self) -> u64 {

--- a/jingle/src/modeling/block.rs
+++ b/jingle/src/modeling/block.rs
@@ -4,14 +4,13 @@ use crate::modeling::branch::BranchConstraint;
 use crate::modeling::state::State;
 use crate::modeling::{ModelingContext, TranslationContext};
 use crate::varnode::ResolvedVarnode;
+use crate::JingleContext;
 use crate::JingleError::EmptyBlock;
-use jingle_sleigh::{Instruction, RegisterManager, VarNode};
 use jingle_sleigh::PcodeOperation;
+use jingle_sleigh::{Instruction};
 use jingle_sleigh::{SpaceInfo, SpaceManager};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
-use z3::Context;
-use crate::JingleContext;
 
 /// A `jingle` model of a basic block
 #[derive(Debug, Clone)]
@@ -62,7 +61,7 @@ impl<'ctx, T: ModelingContext<'ctx>> TryFrom<&'ctx [T]> for ModeledBlock<'ctx> {
 }
 
 impl<'ctx> ModeledBlock<'ctx> {
-    pub fn read<T: Iterator<Item=Instruction>>(
+    pub fn read<T: Iterator<Item = Instruction>>(
         jingle: &JingleContext<'ctx>,
         instr_iter: T,
     ) -> Result<Self, JingleError> {

--- a/jingle/src/modeling/branch.rs
+++ b/jingle/src/modeling/branch.rs
@@ -47,13 +47,19 @@ impl BlockEndBehavior {
         ctx: &'a T,
     ) -> Result<BV<'ctx>, JingleError> {
         match self {
-            Fallthrough(f) => Ok(BV::from_u64(ctx.get_jingle().z3, f.offset, (f.size * 8) as u32)),
+            Fallthrough(f) => Ok(BV::from_u64(
+                ctx.get_jingle().z3,
+                f.offset,
+                (f.size * 8) as u32,
+            )),
             UnconditionalBranch(b) => {
                 match b {
                     // Direct branch
-                    GeneralizedVarNode::Direct(d) => {
-                        Ok(BV::from_u64(ctx.get_jingle().z3, d.offset, (d.size * 8) as u32))
-                    }
+                    GeneralizedVarNode::Direct(d) => Ok(BV::from_u64(
+                        ctx.get_jingle().z3,
+                        d.offset,
+                        (d.size * 8) as u32,
+                    )),
                     // Indirect branch, we want to only inspect the pointer
                     GeneralizedVarNode::Indirect(i) => ctx
                         .get_final_state()

--- a/jingle/src/modeling/branch.rs
+++ b/jingle/src/modeling/branch.rs
@@ -29,7 +29,7 @@ impl BlockEndBehavior {
         ctx: &'a T,
     ) -> Result<BV<'ctx>, JingleError> {
         match self {
-            Fallthrough(f) => Ok(BV::from_u64(ctx.get_z3(), 0, (f.size * 8) as u32)),
+            Fallthrough(f) => Ok(BV::from_u64(ctx.get_jingle().z3, 0, (f.size * 8) as u32)),
             UnconditionalBranch(b) => {
                 match b {
                     // Direct branch
@@ -47,12 +47,12 @@ impl BlockEndBehavior {
         ctx: &'a T,
     ) -> Result<BV<'ctx>, JingleError> {
         match self {
-            Fallthrough(f) => Ok(BV::from_u64(ctx.get_z3(), f.offset, (f.size * 8) as u32)),
+            Fallthrough(f) => Ok(BV::from_u64(ctx.get_jingle().z3, f.offset, (f.size * 8) as u32)),
             UnconditionalBranch(b) => {
                 match b {
                     // Direct branch
                     GeneralizedVarNode::Direct(d) => {
-                        Ok(BV::from_u64(ctx.get_z3(), d.offset, (d.size * 8) as u32))
+                        Ok(BV::from_u64(ctx.get_jingle().z3, d.offset, (d.size * 8) as u32))
                     }
                     // Indirect branch, we want to only inspect the pointer
                     GeneralizedVarNode::Indirect(i) => ctx
@@ -104,14 +104,14 @@ impl BranchConstraint {
                 .get_final_state()
                 .read_varnode(&cond_branch.condition)?
                 ._eq(&BV::from_i64(
-                    ctx.get_z3(),
+                    ctx.get_jingle().z3,
                     0,
                     (cond_branch.condition.size * 8) as u32,
                 ))
                 .not();
             let branch_dest = match &cond_branch.destination {
                 GeneralizedVarNode::Direct(d) => {
-                    BV::from_u64(ctx.get_z3(), d.offset, (d.size * 8) as u32)
+                    BV::from_u64(ctx.get_jingle().z3, d.offset, (d.size * 8) as u32)
                 }
                 GeneralizedVarNode::Indirect(a) => ctx.get_final_state().read(a.into())?,
             };
@@ -130,7 +130,7 @@ impl BranchConstraint {
                 .get_final_state()
                 .read_varnode_metadata(&cond_branch.condition)?
                 ._eq(&BV::from_i64(
-                    ctx.get_z3(),
+                    ctx.get_jingle().z3,
                     0,
                     (&cond_branch.condition.size * 8) as u32,
                 ))

--- a/jingle/src/modeling/instruction.rs
+++ b/jingle/src/modeling/instruction.rs
@@ -10,7 +10,6 @@ use crate::modeling::state::State;
 use crate::varnode::ResolvedVarnode;
 use crate::{JingleContext, JingleError};
 use jingle_sleigh::{SpaceInfo, SpaceManager};
-use z3::Context;
 
 /// A `jingle` model of an individual SLEIGH instruction
 #[derive(Debug, Clone)]
@@ -25,10 +24,7 @@ pub struct ModeledInstruction<'ctx> {
 }
 
 impl<'ctx> ModeledInstruction<'ctx> {
-    pub fn new(
-        instr: Instruction,
-        jingle: &JingleContext<'ctx>,
-    ) -> Result<Self, JingleError> {
+    pub fn new(instr: Instruction, jingle: &JingleContext<'ctx>) -> Result<Self, JingleError> {
         let original_state = State::new(jingle);
         let state = original_state.clone();
         let next_vn = state.get_default_code_space_info().make_varnode(

--- a/jingle/src/modeling/mod.rs
+++ b/jingle/src/modeling/mod.rs
@@ -18,11 +18,11 @@ mod instruction;
 mod slice;
 mod state;
 
+use crate::JingleContext;
 pub use block::ModeledBlock;
 pub use branch::*;
 pub use instruction::ModeledInstruction;
 pub use state::State;
-use crate::JingleContext;
 
 /// `jingle` models straight-line traces of computations. This trait represents all the information
 /// needed to model a given trace.
@@ -185,7 +185,11 @@ pub trait ModelingContext<'ctx>: SpaceManager + Debug + Sized {
     /// branch to the given [u64]
     fn can_branch_to_address(&self, addr: u64) -> Result<Bool<'ctx>, JingleError> {
         let branch_constraint = self.get_branch_constraint().build_bv(self)?;
-        let addr_bv = BV::from_i64(self.get_jingle().z3, addr as i64, branch_constraint.get_size());
+        let addr_bv = BV::from_i64(
+            self.get_jingle().z3,
+            addr as i64,
+            branch_constraint.get_size(),
+        );
         Ok(branch_constraint._eq(&addr_bv))
     }
 }
@@ -497,9 +501,9 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
             }
             PcodeOperation::Int2Comp { input, output } => {
                 let in0 = self.read_and_track(input.into())?;
-                let flipped = in0
-                    .bvneg()
-                    .add(BV::from_u64(self.get_jingle().z3, 1, in0.get_size()));
+                let flipped =
+                    in0.bvneg()
+                        .add(BV::from_u64(self.get_jingle().z3, 1, in0.get_size()));
                 self.write(&output.into(), flipped)
             }
             PcodeOperation::IntSignedLess {
@@ -595,16 +599,16 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
             } => {
                 let i0 = self.read_and_track(input0.into())?;
                 let i1 = self.read_and_track(input1.into())?;
-                let result = i0
-                    .bvand(&i1)
-                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
+                let result =
+                    i0.bvand(&i1)
+                        .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
                 self.write(&output.into(), result)
             }
             PcodeOperation::BoolNegate { input, output } => {
                 let val = self.read_and_track(input.into())?;
-                let negated = val
-                    .bvneg()
-                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, val.get_size()));
+                let negated =
+                    val.bvneg()
+                        .bvand(&BV::from_u64(self.get_jingle().z3, 1, val.get_size()));
                 self.write(&output.into(), negated)
             }
             PcodeOperation::BoolOr {
@@ -614,9 +618,9 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
             } => {
                 let i0 = self.read_and_track(input0.into())?;
                 let i1 = self.read_and_track(input1.into())?;
-                let result = i0
-                    .bvor(&i1)
-                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
+                let result =
+                    i0.bvor(&i1)
+                        .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
                 self.write(&output.into(), result)
             }
             PcodeOperation::BoolXor {
@@ -626,9 +630,9 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
             } => {
                 let i0 = self.read_and_track(input0.into())?;
                 let i1 = self.read_and_track(input1.into())?;
-                let result = i0
-                    .bvxor(&i1)
-                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
+                let result =
+                    i0.bvxor(&i1)
+                        .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
                 self.write(&output.into(), result)
             }
             PcodeOperation::PopCount { input, output } => {

--- a/jingle/src/modeling/mod.rs
+++ b/jingle/src/modeling/mod.rs
@@ -10,7 +10,6 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::{Add, Neg};
 use tracing::instrument;
 use z3::ast::{Ast, Bool, BV};
-use z3::Context;
 
 mod block;
 mod branch;

--- a/jingle/src/modeling/mod.rs
+++ b/jingle/src/modeling/mod.rs
@@ -22,6 +22,7 @@ pub use block::ModeledBlock;
 pub use branch::*;
 pub use instruction::ModeledInstruction;
 pub use state::State;
+use crate::JingleContext;
 
 /// `jingle` models straight-line traces of computations. This trait represents all the information
 /// needed to model a given trace.
@@ -29,8 +30,8 @@ pub use state::State;
 /// defines several helper functions for building formulae
 /// todo: this should probably be separated out with the extension trait pattern
 pub trait ModelingContext<'ctx>: SpaceManager + Debug + Sized {
-    /// Get a handle to the z3 context associated with this modeling context
-    fn get_z3(&self) -> &'ctx Context;
+    /// Get a handle to the jingle context associated with this modeling context
+    fn get_jingle(&self) -> &JingleContext<'ctx>;
 
     /// Get the address this context is associated with (e.g. for an instruction, it is the address,
     /// for a basic block, it is the address of the first instruction).
@@ -110,7 +111,7 @@ pub trait ModelingContext<'ctx>: SpaceManager + Debug + Sized {
         }
         let p_terms: Vec<&Bool> = premise_terms.iter().collect();
 
-        let premise = Bool::and(self.get_z3(), p_terms.as_slice());
+        let premise = Bool::and(self.get_jingle().z3, p_terms.as_slice());
         Ok(premise)
     }
 
@@ -139,7 +140,7 @@ pub trait ModelingContext<'ctx>: SpaceManager + Debug + Sized {
             }
         }
         let imp_terms: Vec<&Bool> = output_terms.iter().collect();
-        let outputs_pairwise_equal = Bool::and(self.get_z3(), imp_terms.as_slice());
+        let outputs_pairwise_equal = Bool::and(self.get_jingle().z3, imp_terms.as_slice());
         Ok(outputs_pairwise_equal)
     }
 
@@ -172,7 +173,7 @@ pub trait ModelingContext<'ctx>: SpaceManager + Debug + Sized {
                 zext_to_match(self_bv_metadata.simplify(), &other_bv_metadata.simplify());
             let other_bv_metadata = zext_to_match(other_bv_metadata, &self_bv_metadata);
             Ok(Some(Bool::and(
-                self.get_z3(),
+                self.get_jingle().z3,
                 &[
                     self_bv._eq(&other_bv).simplify(),
                     self_bv_metadata._eq(&other_bv_metadata).simplify(),
@@ -184,7 +185,7 @@ pub trait ModelingContext<'ctx>: SpaceManager + Debug + Sized {
     /// branch to the given [u64]
     fn can_branch_to_address(&self, addr: u64) -> Result<Bool<'ctx>, JingleError> {
         let branch_constraint = self.get_branch_constraint().build_bv(self)?;
-        let addr_bv = BV::from_i64(self.get_z3(), addr as i64, branch_constraint.get_size());
+        let addr_bv = BV::from_i64(self.get_jingle().z3, addr as i64, branch_constraint.get_size());
         Ok(branch_constraint._eq(&addr_bv))
     }
 }
@@ -458,8 +459,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 // bool arg seems to be for whether this check is signed
                 let carry_bool = in0.bvadd_no_overflow(&in1, false);
                 let out_bv = carry_bool.ite(
-                    &BV::from_i64(self.get_z3(), 0, 8),
-                    &BV::from_i64(self.get_z3(), 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -473,8 +474,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 // bool arg seems to be for whether this check is signed
                 let carry_bool = in0.bvadd_no_overflow(&in1, true);
                 let out_bv = carry_bool.ite(
-                    &BV::from_i64(self.get_z3(), 0, 8),
-                    &BV::from_i64(self.get_z3(), 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -489,8 +490,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 // meaning of "overflow" is in sleigh vs what it means in z3
                 let borrow_bool = in0.bvsub_no_underflow(&in1, true);
                 let out_bv = borrow_bool.ite(
-                    &BV::from_i64(self.get_z3(), 0, 8),
-                    &BV::from_i64(self.get_z3(), 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -498,7 +499,7 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let in0 = self.read_and_track(input.into())?;
                 let flipped = in0
                     .bvneg()
-                    .add(BV::from_u64(self.get_z3(), 1, in0.get_size()));
+                    .add(BV::from_u64(self.get_jingle().z3, 1, in0.get_size()));
                 self.write(&output.into(), flipped)
             }
             PcodeOperation::IntSignedLess {
@@ -510,8 +511,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let in1 = self.read_and_track(input1.into())?;
                 let out_bool = in0.bvslt(&in1);
                 let out_bv = out_bool.ite(
-                    &BV::from_i64(self.get_z3(), 1, 8),
-                    &BV::from_i64(self.get_z3(), 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -524,8 +525,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let in1 = self.read_and_track(input1.into())?;
                 let out_bool = in0.bvsle(&in1);
                 let out_bv = out_bool.ite(
-                    &BV::from_i64(self.get_z3(), 1, 8),
-                    &BV::from_i64(self.get_z3(), 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -538,8 +539,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let in1 = self.read_and_track(input1.into())?;
                 let out_bool = in0.bvult(&in1);
                 let out_bv = out_bool.ite(
-                    &BV::from_i64(self.get_z3(), 1, 8),
-                    &BV::from_i64(self.get_z3(), 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -552,8 +553,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let in1 = self.read_and_track(input1.into())?;
                 let out_bool = in0.bvule(&in1);
                 let out_bv = out_bool.ite(
-                    &BV::from_i64(self.get_z3(), 1, 8),
-                    &BV::from_i64(self.get_z3(), 0, 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -567,8 +568,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let outsize = output.size as u32;
                 let out_bool = in0._eq(&in1);
                 let out_bv = out_bool.ite(
-                    &BV::from_i64(self.get_z3(), 1, outsize * 8),
-                    &BV::from_i64(self.get_z3(), 0, outsize * 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, outsize * 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, outsize * 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -582,8 +583,8 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let outsize = output.size as u32;
                 let out_bool = in0._eq(&in1).not();
                 let out_bv = out_bool.ite(
-                    &BV::from_i64(self.get_z3(), 1, outsize * 8),
-                    &BV::from_i64(self.get_z3(), 0, outsize * 8),
+                    &BV::from_i64(self.get_jingle().z3, 1, outsize * 8),
+                    &BV::from_i64(self.get_jingle().z3, 0, outsize * 8),
                 );
                 self.write(&output.into(), out_bv)
             }
@@ -596,14 +597,14 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let i1 = self.read_and_track(input1.into())?;
                 let result = i0
                     .bvand(&i1)
-                    .bvand(&BV::from_u64(self.get_z3(), 1, i0.get_size()));
+                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
                 self.write(&output.into(), result)
             }
             PcodeOperation::BoolNegate { input, output } => {
                 let val = self.read_and_track(input.into())?;
                 let negated = val
                     .bvneg()
-                    .bvand(&BV::from_u64(self.get_z3(), 1, val.get_size()));
+                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, val.get_size()));
                 self.write(&output.into(), negated)
             }
             PcodeOperation::BoolOr {
@@ -615,7 +616,7 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let i1 = self.read_and_track(input1.into())?;
                 let result = i0
                     .bvor(&i1)
-                    .bvand(&BV::from_u64(self.get_z3(), 1, i0.get_size()));
+                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
                 self.write(&output.into(), result)
             }
             PcodeOperation::BoolXor {
@@ -627,13 +628,13 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 let i1 = self.read_and_track(input1.into())?;
                 let result = i0
                     .bvxor(&i1)
-                    .bvand(&BV::from_u64(self.get_z3(), 1, i0.get_size()));
+                    .bvand(&BV::from_u64(self.get_jingle().z3, 1, i0.get_size()));
                 self.write(&output.into(), result)
             }
             PcodeOperation::PopCount { input, output } => {
                 let size = output.size as u32;
                 let in0 = self.read_and_track(input.into())?;
-                let mut outbv = BV::from_i64(self.get_z3(), 0, output.size as u32 * 8);
+                let mut outbv = BV::from_i64(self.get_jingle().z3, 0, output.size as u32 * 8);
                 for i in 0..size * 8 {
                     let extract = in0.extract(i, i);
                     let extend = extract.zero_ext((size * 8) - 1);
@@ -715,7 +716,7 @@ pub(crate) trait TranslationContext<'ctx>: ModelingContext<'ctx> {
                 self.get_branch_builder().set_last(&hash_vn.into());
                 if let Some(out) = output {
                     let size = out.size * 8;
-                    let hash_bv = BV::from_u64(self.get_z3(), hash, size as u32);
+                    let hash_bv = BV::from_u64(self.get_jingle().z3, hash, size as u32);
                     let metadata = self
                         .get_final_state()
                         .immediate_metadata_array(true, out.size);

--- a/jingle/src/modeling/slice.rs
+++ b/jingle/src/modeling/slice.rs
@@ -3,10 +3,11 @@ use crate::varnode::ResolvedVarnode;
 use jingle_sleigh::PcodeOperation;
 use std::collections::HashSet;
 use z3::Context;
+use crate::JingleContext;
 
 impl<'ctx, T: ModelingContext<'ctx>> ModelingContext<'ctx> for &[T] {
-    fn get_z3(&self) -> &'ctx Context {
-        self[0].get_z3()
+    fn get_jingle(&self) -> &JingleContext<'ctx> {
+        self[0].get_jingle()
     }
 
     fn get_address(&self) -> u64 {

--- a/jingle/src/modeling/slice.rs
+++ b/jingle/src/modeling/slice.rs
@@ -1,9 +1,8 @@
 use crate::modeling::{BranchConstraint, ModelingContext, State};
 use crate::varnode::ResolvedVarnode;
+use crate::JingleContext;
 use jingle_sleigh::PcodeOperation;
 use std::collections::HashSet;
-use z3::Context;
-use crate::JingleContext;
 
 impl<'ctx, T: ModelingContext<'ctx>> ModelingContext<'ctx> for &[T] {
     fn get_jingle(&self) -> &JingleContext<'ctx> {

--- a/jingle/src/modeling/state/mod.rs
+++ b/jingle/src/modeling/state/mod.rs
@@ -8,49 +8,60 @@ use crate::error::JingleError::{
 
 use crate::modeling::state::space::ModeledSpace;
 use crate::varnode::ResolvedVarnode;
-use jingle_sleigh::{
-    GeneralizedVarNode, IndirectVarNode, SpaceInfo, SpaceManager, SpaceType, VarNode,
-};
+use jingle_sleigh::{GeneralizedVarNode, IndirectVarNode, RegisterManager, SpaceInfo, SpaceManager, SpaceType, VarNode};
 use std::ops::Add;
+use std::rc::Rc;
 use z3::ast::{Array, Ast, Bool, BV};
 use z3::Context;
+use crate::JingleContext;
 
 /// Represents the modeled combined memory state of the system. State
 /// is represented with Z3 formulas built up as select and store operations
 /// on an initial state
 #[derive(Clone, Debug)]
 pub struct State<'ctx> {
-    z3: &'ctx Context,
-    space_info: Vec<SpaceInfo>,
+    jingle: JingleContext<'ctx>,
     spaces: Vec<ModeledSpace<'ctx>>,
-    default_code_space_index: usize,
 }
 
 impl<'ctx> SpaceManager for State<'ctx> {
     fn get_space_info(&self, idx: usize) -> Option<&SpaceInfo> {
-        self.space_info.get(idx)
+        self.jingle.get_space_info(idx)
     }
 
     fn get_all_space_info(&self) -> &[SpaceInfo] {
-        self.space_info.as_slice()
+        self.jingle.get_all_space_info()
     }
 
     fn get_code_space_idx(&self) -> usize {
-        self.default_code_space_index
+        self.jingle.get_code_space_idx()
+    }
+}
+
+impl<'ctx> RegisterManager for State<'ctx> {
+    fn get_register(&self, name: &str) -> Option<VarNode> {
+        self.jingle.get_register(name)
+    }
+
+    fn get_register_name(&self, location: &VarNode) -> Option<&str> {
+        self.jingle.get_register_name(location)
+    }
+
+    fn get_registers(&self) -> Vec<(VarNode, String)> {
+        self.jingle.get_registers()
     }
 }
 
 impl<'ctx> State<'ctx> {
-    pub fn new<T: SpaceManager>(z3: &'ctx Context, other: &T) -> Self {
-        let mut s: Self = Self {
-            z3,
-            space_info: other.get_all_space_info().to_vec(),
-            spaces: Default::default(),
-            default_code_space_index: other.get_code_space_idx(),
-        };
-        for space_info in other.get_all_space_info() {
-            s.spaces.push(ModeledSpace::new(s.z3, space_info));
+    pub fn new(jingle: &JingleContext<'ctx>) -> Self {
+        let mut spaces: Vec<ModeledSpace> = Default::default();
+        for space_info in jingle.get_all_space_info() {
+            spaces.push(ModeledSpace::new(jingle, space_info));
         }
+        let mut s: Self = Self {
+            jingle: jingle.clone(),
+            spaces: Default::default(),
+        };
         s
     }
 
@@ -67,13 +78,13 @@ impl<'ctx> State<'ctx> {
             .ok_or(UnmodeledSpace)?;
         match space._type {
             SpaceType::IPTR_CONSTANT => Ok(BV::from_i64(
-                self.z3,
+                self.jingle.z3,
                 varnode.offset as i64,
                 (varnode.size * 8) as u32,
             )),
             _ => {
                 let offset =
-                    BV::from_i64(self.z3, varnode.offset as i64, space.index_size_bytes * 8);
+                    BV::from_i64(self.jingle.z3, varnode.offset as i64, space.index_size_bytes * 8);
                 let arr = self.spaces.get(varnode.space_index).ok_or(UnmodeledSpace)?;
                 arr.read_data(&offset, varnode.size)
             }
@@ -85,7 +96,7 @@ impl<'ctx> State<'ctx> {
             .get_space_info(varnode.space_index)
             .ok_or(UnmodeledSpace)?;
 
-        let offset = BV::from_i64(self.z3, varnode.offset as i64, space.index_size_bytes * 8);
+        let offset = BV::from_i64(self.jingle.z3, varnode.offset as i64, space.index_size_bytes * 8);
         let arr = self.spaces.get(varnode.space_index).ok_or(UnmodeledSpace)?;
         arr.read_metadata(&offset, varnode.size)
     }
@@ -151,7 +162,8 @@ impl<'ctx> State<'ctx> {
         if dest.size as u32 * 8 != val.get_size() {
             return Err(MismatchedWordSize);
         }
-        match self.space_info[dest.space_index]._type {
+        let info = self.jingle.get_space_info(dest.space_index).ok_or(UnmodeledSpace)?;
+        match info._type {
             SpaceType::IPTR_CONSTANT => Err(ConstantWrite),
             _ => {
                 let space = self
@@ -161,9 +173,9 @@ impl<'ctx> State<'ctx> {
                 space.write_data(
                     &val,
                     &BV::from_u64(
-                        self.z3,
+                        self.jingle.z3,
                         dest.offset,
-                        self.space_info[dest.space_index].index_size_bytes * 8,
+                        info.index_size_bytes * 8,
                     ),
                 )?;
                 Ok(())
@@ -185,12 +197,14 @@ impl<'ctx> State<'ctx> {
             .spaces
             .get_mut(dest.space_index)
             .ok_or(UnmodeledSpace)?;
+        let info = self.jingle.get_space_info(dest.space_index).ok_or(UnmodeledSpace)?;
+
         space.write_metadata(
             &val,
             &BV::from_u64(
-                self.z3,
+                self.jingle.z3,
                 dest.offset,
-                self.space_info[dest.space_index].index_size_bytes * 8,
+                info.index_size_bytes * 8,
             ),
         )?;
         Ok(())
@@ -202,7 +216,9 @@ impl<'ctx> State<'ctx> {
         dest: &IndirectVarNode,
         val: BV<'ctx>,
     ) -> Result<(), JingleError> {
-        if self.space_info[dest.pointer_space_index]._type == SpaceType::IPTR_CONSTANT {
+        let info = self.jingle.get_space_info(dest.pointer_space_index).ok_or(UnmodeledSpace)?;
+
+        if info._type == SpaceType::IPTR_CONSTANT {
             return Err(ConstantWrite);
         }
         let ptr = self.read_varnode(&dest.pointer_location)?;
@@ -215,7 +231,9 @@ impl<'ctx> State<'ctx> {
         dest: &IndirectVarNode,
         val: BV<'ctx>,
     ) -> Result<(), JingleError> {
-        if self.space_info[dest.pointer_space_index]._type == SpaceType::IPTR_CONSTANT {
+        let info = self.jingle.get_space_info(dest.pointer_space_index).ok_or(UnmodeledSpace)?;
+
+        if info._type == SpaceType::IPTR_CONSTANT {
             return Err(ConstantWrite);
         }
         let ptr = self.read_varnode(&dest.pointer_location)?;
@@ -245,11 +263,11 @@ impl<'ctx> State<'ctx> {
     }
 
     pub fn get_default_code_space(&self) -> &Array<'ctx> {
-        self.spaces[self.default_code_space_index].get_space()
+        self.spaces[self.jingle.get_code_space_idx()].get_space()
     }
 
     pub fn get_default_code_space_info(&self) -> &SpaceInfo {
-        &self.space_info[self.default_code_space_index]
+        &self.jingle.get_space_info(self.jingle.get_code_space_idx()).unwrap()
     }
 
     pub(crate) fn immediate_metadata_array(&self, val: bool, s: usize) -> BV<'ctx> {
@@ -258,7 +276,7 @@ impl<'ctx> State<'ctx> {
             false => 0,
         };
         (0..s)
-            .map(|_| BV::from_u64(self.z3, val, 1))
+            .map(|_| BV::from_u64(self.jingle.z3, val, 1))
             .reduce(|a, b| a.concat(&b))
             .map(|b| b.simplify())
             .unwrap()
@@ -277,6 +295,6 @@ impl<'ctx> State<'ctx> {
             terms.push(self_space._eq(other_space))
         }
         let eq_terms: Vec<&Bool> = terms.iter().collect();
-        Ok(Bool::and(self.z3, eq_terms.as_slice()))
+        Ok(Bool::and(self.jingle.z3, eq_terms.as_slice()))
     }
 }

--- a/jingle/src/modeling/state/space.rs
+++ b/jingle/src/modeling/state/space.rs
@@ -1,10 +1,9 @@
-use crate::{JingleContext, JingleError};
 use crate::JingleError::{MismatchedAddressSize, UnexpectedArraySort, ZeroSizedVarnode};
+use crate::{JingleContext, JingleError};
 use jingle_sleigh::{SleighEndianness, SpaceInfo};
 use std::ops::Add;
-use std::rc::Rc;
 use z3::ast::{Array, BV};
-use z3::{Context, Sort};
+use z3::Sort;
 
 /// SLEIGH models programs using many spaces. This struct serves as a helper for modeling a single
 /// space. `jingle` uses an SMT Array sort to model a space.
@@ -135,14 +134,17 @@ fn write_to_array<'ctx, const W: u32>(
 #[cfg(test)]
 mod tests {
     use crate::modeling::state::space::ModeledSpace;
+    use crate::tests::SLEIGH_ARCH;
+    use crate::JingleContext;
+    use jingle_sleigh::context::SleighContextBuilder;
     use jingle_sleigh::{SleighEndianness, SpaceInfo, SpaceType};
     use z3::ast::{Ast, BV};
     use z3::{Config, Context};
-    use jingle_sleigh::context::SleighContextBuilder;
-    use crate::JingleContext;
-    use crate::tests::SLEIGH_ARCH;
 
-    fn make_space<'ctx>(z3: &JingleContext<'ctx>, endianness: SleighEndianness) -> ModeledSpace<'ctx> {
+    fn make_space<'ctx>(
+        z3: &JingleContext<'ctx>,
+        endianness: SleighEndianness,
+    ) -> ModeledSpace<'ctx> {
         let space_info = SpaceInfo {
             endianness,
             name: "ram".to_string(),

--- a/jingle/src/modeling/state/space.rs
+++ b/jingle/src/modeling/state/space.rs
@@ -1,7 +1,8 @@
-use crate::JingleError;
+use crate::{JingleContext, JingleError};
 use crate::JingleError::{MismatchedAddressSize, UnexpectedArraySort, ZeroSizedVarnode};
 use jingle_sleigh::{SleighEndianness, SpaceInfo};
 use std::ops::Add;
+use std::rc::Rc;
 use z3::ast::{Array, BV};
 use z3::{Context, Sort};
 
@@ -23,13 +24,13 @@ pub(crate) struct ModeledSpace<'ctx> {
 
 impl<'ctx> ModeledSpace<'ctx> {
     /// Create a new modeling space with the given z3 context, using the provided space metadata
-    pub(crate) fn new(z3: &'ctx Context, space_info: &SpaceInfo) -> Self {
-        let domain = Sort::bitvector(z3, space_info.index_size_bytes * 8);
-        let range = Sort::bitvector(z3, space_info.word_size_bytes * 8);
+    pub(crate) fn new(jingle: &JingleContext<'ctx>, space_info: &SpaceInfo) -> Self {
+        let domain = Sort::bitvector(jingle.z3, space_info.index_size_bytes * 8);
+        let range = Sort::bitvector(jingle.z3, space_info.word_size_bytes * 8);
         Self {
             endianness: space_info.endianness,
-            data: Array::fresh_const(z3, &space_info.name, &domain, &range),
-            metadata: Array::const_array(z3, &domain, &BV::from_u64(z3, 0, 1)),
+            data: Array::fresh_const(jingle.z3, &space_info.name, &domain, &range),
+            metadata: Array::const_array(jingle.z3, &domain, &BV::from_u64(jingle.z3, 0, 1)),
             space_info: space_info.clone(),
         }
     }
@@ -137,8 +138,11 @@ mod tests {
     use jingle_sleigh::{SleighEndianness, SpaceInfo, SpaceType};
     use z3::ast::{Ast, BV};
     use z3::{Config, Context};
+    use jingle_sleigh::context::SleighContextBuilder;
+    use crate::JingleContext;
+    use crate::tests::SLEIGH_ARCH;
 
-    fn make_space(z3: &Context, endianness: SleighEndianness) -> ModeledSpace {
+    fn make_space<'ctx>(z3: &JingleContext<'ctx>, endianness: SleighEndianness) -> ModeledSpace<'ctx> {
         let space_info = SpaceInfo {
             endianness,
             name: "ram".to_string(),
@@ -150,8 +154,12 @@ mod tests {
         ModeledSpace::new(z3, &space_info)
     }
     fn test_endian_write(e: SleighEndianness) {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
         let z3 = Context::new(&Config::new());
-        let mut space = make_space(&z3, e);
+        let jingle = JingleContext::new(&z3, &sleigh);
+        let mut space = make_space(&jingle, e);
         space
             .write_data(
                 &BV::from_u64(&z3, 0xdead_beef, 32),
@@ -173,8 +181,12 @@ mod tests {
     }
 
     fn test_endian_read(e: SleighEndianness) {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
         let z3 = Context::new(&Config::new());
-        let mut space = make_space(&z3, e);
+        let jingle = JingleContext::new(&z3, &sleigh);
+        let mut space = make_space(&jingle, e);
         let byte_layout = match e {
             SleighEndianness::Big => [0xde, 0xad, 0xbe, 0xef],
             SleighEndianness::Little => [0xef, 0xbe, 0xad, 0xde],
@@ -196,8 +208,12 @@ mod tests {
     }
 
     fn test_single_write(e: SleighEndianness) {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
         let z3 = Context::new(&Config::new());
-        let mut space = make_space(&z3, e);
+        let jingle = JingleContext::new(&z3, &sleigh);
+        let mut space = make_space(&jingle, e);
         space
             .write_data(&BV::from_u64(&z3, 0x42, 8), &BV::from_u64(&z3, 0, 32))
             .unwrap();

--- a/jingle/src/translator.rs
+++ b/jingle/src/translator.rs
@@ -2,11 +2,11 @@ use crate::error::JingleError;
 use jingle_sleigh::{Instruction, RegisterManager, SpaceInfo, VarNode};
 
 use crate::modeling::ModeledInstruction;
+use crate::JingleContext;
 use jingle_sleigh::context::loaded::LoadedSleighContext;
 use jingle_sleigh::JingleSleighError::InstructionDecode;
 use jingle_sleigh::SpaceManager;
 use z3::Context;
-use crate::JingleContext;
 
 /// This type wraps z3 and a sleigh context and allows for both modeling instructions that
 /// sleigh context has already produced, or reading new instructions directly out of sleigh and

--- a/jingle/src/translator.rs
+++ b/jingle/src/translator.rs
@@ -6,20 +6,22 @@ use jingle_sleigh::context::loaded::LoadedSleighContext;
 use jingle_sleigh::JingleSleighError::InstructionDecode;
 use jingle_sleigh::SpaceManager;
 use z3::Context;
+use crate::JingleContext;
 
 /// This type wraps z3 and a sleigh context and allows for both modeling instructions that
 /// sleigh context has already produced, or reading new instructions directly out of sleigh and
 /// modeling them in one go
 #[derive(Debug, Clone)]
 pub struct SleighTranslator<'ctx> {
-    z3_ctx: &'ctx Context,
+    jingle: JingleContext<'ctx>,
     sleigh: &'ctx LoadedSleighContext<'ctx>,
 }
 
 impl<'ctx> SleighTranslator<'ctx> {
     /// Make a new sleigh translator
     pub fn new(sleigh: &'ctx LoadedSleighContext, z3_ctx: &'ctx Context) -> Self {
-        Self { z3_ctx, sleigh }
+        let jingle = JingleContext::new(z3_ctx, sleigh);
+        Self { jingle, sleigh }
     }
 
     /// Ask sleigh to read one instruction from the given offset and attempt
@@ -41,7 +43,7 @@ impl<'ctx> SleighTranslator<'ctx> {
         &self,
         instr: Instruction,
     ) -> Result<ModeledInstruction<'ctx>, JingleError> {
-        ModeledInstruction::new(instr, self.sleigh, self.z3_ctx)
+        ModeledInstruction::new(instr, &self.jingle)
     }
 }
 

--- a/jingle_sleigh/src/context/loaded.rs
+++ b/jingle_sleigh/src/context/loaded.rs
@@ -134,7 +134,7 @@ impl<'a> LoadedSleighContext<'a> {
     /// Returns an iterator of entries describing the sections of the configured image provider.
     pub fn get_sections(&self) -> impl Iterator<Item = ImageSection> {
         self.img.provider.get_section_info().map(|mut s| {
-            s.base_address = s.base_address + self.get_base_address() as usize;
+            s.base_address += self.get_base_address() as usize;
             s
         })
     }


### PR DESCRIPTION
* Breaks out `JingleContext` into an internal object and a transparent wrapper type, which stores the actual context in an `Rc`. This is fine because:
  *  This isn't something that's going to be running in `nostd` contexts, and we're using allocation elsewhere anyway
  *  This structure is basically a wrapper around `z3`'s `Context`, providing `p-code`-specific functionality. Since `Context` is not `Send` or `Sync`, this can't be either, so `Rc` doesn't impose any new limitations.
* Impls `Clone` on `JingleContext`, thanks to the `Rc`.
* Places a `JingleContext` handle in many structs instead of duplicating the context's information. This removes a lot of boilerplate repetition.