### PR TITLE
Change iterator to not work specifically on BVs

### DIFF
--- a/jingle/src/python/modeled_block.rs
+++ b/jingle/src/python/modeled_block.rs
@@ -52,7 +52,6 @@ impl PythonModeledBlock {
             .into_iter()
             .flat_map(|i| i.ops)
             .flat_map(|op| op.inputs())
-            .into_iter()
             .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;
@@ -70,7 +69,6 @@ impl PythonModeledBlock {
             .into_iter()
             .flat_map(|i| i.ops)
             .flat_map(|op| op.output())
-            .into_iter()
             .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;

--- a/jingle/src/python/modeled_block.rs
+++ b/jingle/src/python/modeled_block.rs
@@ -2,7 +2,7 @@ use crate::modeling::{ModeledBlock, ModelingContext};
 use crate::python::state::PythonState;
 use crate::python::varode_iterator::VarNodeIterator;
 use crate::sleigh::Instruction;
-use crate::{JingleContext};
+use crate::JingleContext;
 use jingle_sleigh::GeneralizedVarNodeDisplay;
 use pyo3::{pyclass, pymethods, PyResult};
 
@@ -48,13 +48,12 @@ impl PythonModeledBlock {
         let filtered: Result<Vec<GeneralizedVarNodeDisplay>, _> = self
             .instr
             .instructions
-            .clone().into_iter()
+            .clone()
+            .into_iter()
             .flat_map(|i| i.ops)
             .flat_map(|op| op.inputs())
             .into_iter()
-            .map(|g| {
-                g.display(self.instr.get_final_state())
-            })
+            .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;
         Ok(VarNodeIterator::new(filtered.into_iter()))
@@ -67,13 +66,12 @@ impl PythonModeledBlock {
         let filtered: Result<Vec<GeneralizedVarNodeDisplay>, _> = self
             .instr
             .instructions
-            .clone().into_iter()
+            .clone()
+            .into_iter()
             .flat_map(|i| i.ops)
             .flat_map(|op| op.output())
             .into_iter()
-            .map(|g| {
-                g.display(self.instr.get_final_state())
-            })
+            .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;
         Ok(VarNodeIterator::new(filtered.into_iter()))

--- a/jingle/src/python/modeled_block.rs
+++ b/jingle/src/python/modeled_block.rs
@@ -2,7 +2,8 @@ use crate::modeling::{ModeledBlock, ModelingContext};
 use crate::python::state::PythonState;
 use crate::python::varode_iterator::VarNodeIterator;
 use crate::sleigh::Instruction;
-use crate::JingleContext;
+use crate::{JingleContext};
+use jingle_sleigh::GeneralizedVarNodeDisplay;
 use pyo3::{pyclass, pymethods, PyResult};
 
 #[pyclass(unsendable)]
@@ -43,34 +44,38 @@ impl PythonModeledBlock {
     /// A list of the input varnodes to the block, filtering
     /// for only those representing actual locations in processor memory:
     /// constants and "internal" varnodes are filtered out
-    pub fn get_input_bvs(&self) -> VarNodeIterator {
-        let filtered: Vec<_> = self
+    pub fn get_input_bvs(&self) -> PyResult<VarNodeIterator> {
+        let filtered: Result<Vec<GeneralizedVarNodeDisplay>, _> = self
             .instr
-            .get_outputs()
+            .instructions
+            .clone().into_iter()
+            .flat_map(|i| i.ops)
+            .flat_map(|op| op.inputs())
             .into_iter()
-            .filter(|o| self.instr.should_varnode_constrain(o))
+            .map(|g| {
+                g.display(self.instr.get_final_state())
+            })
             .collect();
-        VarNodeIterator::new(
-            // intentional: that AST has the input in it too
-            self.instr.get_final_state().clone(),
-            filtered.into_iter(),
-        )
+        let filtered = filtered?;
+        Ok(VarNodeIterator::new(filtered.into_iter()))
     }
 
     /// A list of the output varnodes to the block, filtering
     /// for only those representing actual locations in processor memory:
     /// "internal" varnodes are filtered out
-    pub fn get_output_bvs(&self) -> VarNodeIterator {
-        let filtered: Vec<_> = self
+    pub fn get_output_bvs(&self) -> PyResult<VarNodeIterator> {
+        let filtered: Result<Vec<GeneralizedVarNodeDisplay>, _> = self
             .instr
-            .get_outputs()
+            .instructions
+            .clone().into_iter()
+            .flat_map(|i| i.ops)
+            .flat_map(|op| op.output())
             .into_iter()
-            .filter(|o| self.instr.should_varnode_constrain(o))
+            .map(|g| {
+                g.display(self.instr.get_final_state())
+            })
             .collect();
-        VarNodeIterator::new(
-            // intentional: that AST has the input in it too
-            self.instr.get_final_state().clone(),
-            filtered.into_iter(),
-        )
+        let filtered = filtered?;
+        Ok(VarNodeIterator::new(filtered.into_iter()))
     }
 }

--- a/jingle/src/python/modeled_instruction.rs
+++ b/jingle/src/python/modeled_instruction.rs
@@ -48,12 +48,13 @@ impl PythonModeledInstruction {
     /// for only those representing actual locations in processor memory:
     /// constants and "internal" varnodes are filtered out
     pub fn get_input_bvs(&self) -> PyResult<VarNodeIterator> {
-        let filtered: Result<Vec<_>,_> = self
+        let filtered: Result<Vec<_>, _> = self
             .instr
             .instr
             .clone()
             .ops
-            .into_iter().flat_map(|op| op.inputs())
+            .into_iter()
+            .flat_map(|op| op.inputs())
             .into_iter()
             .map(|g| g.display(self.instr.get_final_state()))
             .collect();
@@ -65,17 +66,17 @@ impl PythonModeledInstruction {
     /// for only those representing actual locations in processor memory:
     /// "internal" varnodes are filtered out
     pub fn get_output_bvs(&self) -> PyResult<VarNodeIterator> {
-        let filtered: Result<Vec<_>,_> = self
+        let filtered: Result<Vec<_>, _> = self
             .instr
             .instr
             .clone()
             .ops
-            .into_iter().flat_map(|op| op.output())
+            .into_iter()
+            .flat_map(|op| op.output())
             .into_iter()
             .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;
         Ok(VarNodeIterator::new(filtered.into_iter()))
-
     }
 }

--- a/jingle/src/python/modeled_instruction.rs
+++ b/jingle/src/python/modeled_instruction.rs
@@ -47,34 +47,35 @@ impl PythonModeledInstruction {
     /// A list of the input varnodes to the instruction, filtering
     /// for only those representing actual locations in processor memory:
     /// constants and "internal" varnodes are filtered out
-    pub fn get_input_bvs(&self) -> VarNodeIterator {
-        let filtered: Vec<_> = self
+    pub fn get_input_bvs(&self) -> PyResult<VarNodeIterator> {
+        let filtered: Result<Vec<_>,_> = self
             .instr
-            .get_outputs()
+            .instr
+            .clone()
+            .ops
+            .into_iter().flat_map(|op| op.inputs())
             .into_iter()
-            .filter(|o| self.instr.should_varnode_constrain(o))
+            .map(|g| g.display(self.instr.get_final_state()))
             .collect();
-        VarNodeIterator::new(
-            // intentional: that AST has the input in it too
-            self.instr.get_final_state().clone(),
-            filtered.into_iter(),
-        )
+        let filtered = filtered?;
+        Ok(VarNodeIterator::new(filtered.into_iter()))
     }
 
     /// A list of the output varnodes to the instruction, filtering
     /// for only those representing actual locations in processor memory:
     /// "internal" varnodes are filtered out
-    pub fn get_output_bvs(&self) -> VarNodeIterator {
-        let filtered: Vec<_> = self
+    pub fn get_output_bvs(&self) -> PyResult<VarNodeIterator> {
+        let filtered: Result<Vec<_>,_> = self
             .instr
-            .get_outputs()
+            .instr
+            .clone()
+            .ops
+            .into_iter().flat_map(|op| op.output())
             .into_iter()
-            .filter(|o| self.instr.should_varnode_constrain(o))
+            .map(|g| g.display(self.instr.get_final_state()))
             .collect();
-        VarNodeIterator::new(
-            // intentional: that AST has the input in it too
-            self.instr.get_final_state().clone(),
-            filtered.into_iter(),
-        )
+        let filtered = filtered?;
+        Ok(VarNodeIterator::new(filtered.into_iter()))
+
     }
 }

--- a/jingle/src/python/modeled_instruction.rs
+++ b/jingle/src/python/modeled_instruction.rs
@@ -55,7 +55,6 @@ impl PythonModeledInstruction {
             .ops
             .into_iter()
             .flat_map(|op| op.inputs())
-            .into_iter()
             .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;
@@ -73,7 +72,6 @@ impl PythonModeledInstruction {
             .ops
             .into_iter()
             .flat_map(|op| op.output())
-            .into_iter()
             .map(|g| g.display(self.instr.get_final_state()))
             .collect();
         let filtered = filtered?;

--- a/jingle/src/python/varode_iterator.rs
+++ b/jingle/src/python/varode_iterator.rs
@@ -1,21 +1,17 @@
-use crate::modeling::State;
-use crate::python::z3::ast::TryIntoPythonZ3;
-use crate::varnode::ResolvedVarnode;
-use pyo3::{pyclass, pymethods, Py, PyAny, PyRef, PyRefMut};
+
+use pyo3::{pyclass, pymethods, PyRef, PyRefMut};
+use jingle_sleigh::GeneralizedVarNodeDisplay;
 
 #[pyclass(unsendable)]
 pub struct VarNodeIterator {
-    state: State<'static>,
-    vn: Box<dyn Iterator<Item = ResolvedVarnode<'static>>>,
+    vn: Box<dyn Iterator<Item = GeneralizedVarNodeDisplay>>,
 }
 
 impl VarNodeIterator {
-    pub fn new<T: Iterator<Item = ResolvedVarnode<'static>> + 'static>(
-        state: State<'static>,
+    pub fn new<T: Iterator<Item = GeneralizedVarNodeDisplay> + 'static>(
         t: T,
     ) -> Self {
         Self {
-            state,
             vn: Box::new(t),
         }
     }
@@ -26,10 +22,7 @@ impl VarNodeIterator {
         slf
     }
 
-    pub fn __next__(mut slf: PyRefMut<Self>) -> Option<Py<PyAny>> {
-        let vn = slf.vn.next()?;
-        let vn = slf.state.read_resolved(&vn).ok()?;
-        let bv = vn.try_into_python().ok()?;
-        Some(bv)
+    pub fn __next__(mut slf: PyRefMut<Self>) -> Option<GeneralizedVarNodeDisplay> {
+        slf.vn.next()
     }
 }

--- a/jingle/src/python/varode_iterator.rs
+++ b/jingle/src/python/varode_iterator.rs
@@ -1,6 +1,5 @@
-
-use pyo3::{pyclass, pymethods, PyRef, PyRefMut};
 use jingle_sleigh::GeneralizedVarNodeDisplay;
+use pyo3::{pyclass, pymethods, PyRef, PyRefMut};
 
 #[pyclass(unsendable)]
 pub struct VarNodeIterator {
@@ -8,12 +7,8 @@ pub struct VarNodeIterator {
 }
 
 impl VarNodeIterator {
-    pub fn new<T: Iterator<Item = GeneralizedVarNodeDisplay> + 'static>(
-        t: T,
-    ) -> Self {
-        Self {
-            vn: Box::new(t),
-        }
+    pub fn new<T: Iterator<Item = GeneralizedVarNodeDisplay> + 'static>(t: T) -> Self {
+        Self { vn: Box::new(t) }
     }
 }
 #[pymethods]


### PR DESCRIPTION
Make the iterator just track varnodes/indirect varnodes and not "resolved" (bitvector) versions of the same. Need to caveat in the documentation that reading an indirect varnode directly from a state will evaluate both the _pointer_ AND the _pointed to_ data from the given state. If this is NOT what you want (e.g. want to read the initial state of the data pointed to by a pointer in the FINAL state, this read needs to be done in two steps: the pointer in the final state, the pointed-to data using the pointer, in the initial state. There is currently NOT a way to do this from the python API. If that becomes necessary, can just make a "BV" version of this or some other adapter to allow constructing "bv" indirect varnodes from pointers.