### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.1.1...jingle-v0.1.2) - 2025-07-10
+
+### Other
+
+- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
+- Use latest z3 ([#65](https://github.com/toolCHAINZ/jingle/pull/65))
+- Add varnode covering logic ([#59](https://github.com/toolCHAINZ/jingle/pull/59))
+- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
+- Add method to get instructions from a block in python ([#55](https://github.com/toolCHAINZ/jingle/pull/55))
+- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
+- pub ctx
+- Add some [Partial]Eq derives
+- fmt
+- Improved location concretization
+- Extend Python Z3 Interop ([#51](https://github.com/toolCHAINZ/jingle/pull/51))
+- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
+- pub
+- Add some methods
+- fmt + clippy
+- Add another display
+- Add display => str
+- More python varnode representation tweaks
+- fmt + clippy
+- Add iter impl
+- Fix names
+- Change iterator to not work specifically on BVs ([#50](https://github.com/toolCHAINZ/jingle/pull/50))
+- Expose more structs ([#49](https://github.com/toolCHAINZ/jingle/pull/49))
+- Python/Rust Conversion Trait ([#48](https://github.com/toolCHAINZ/jingle/pull/48))
+- Change wrapping of pythong z3
+- Pub instr
+- Python refactor ([#46](https://github.com/toolCHAINZ/jingle/pull/46))
+- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
+- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
+- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
+- API Cleanup ([#35](https://github.com/toolCHAINZ/jingle/pull/35))
+- Merge dev changes ([#31](https://github.com/toolCHAINZ/jingle/pull/31))

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"
@@ -19,7 +19,7 @@ name = "jingle"
 required-features = ["bin_features"]
 
 [dependencies]
-jingle_sleigh = { path = "../jingle_sleigh", version = "0.1.1" }
+jingle_sleigh = { path = "../jingle_sleigh", version = "0.1.2" }
 z3 = "0.13.0"
 z3-sys = { version = "0.9.0", optional = true }
 thiserror = "2.0"

--- a/jingle_python/CHANGELOG.md
+++ b/jingle_python/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/toolCHAINZ/jingle/releases/tag/jingle_python-v0.1.1) - 2025-07-10
+
+### Other
+
+- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
+- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
+- Add forgotten type annotation
+- Fix python z3 import error ([#54](https://github.com/toolCHAINZ/jingle/pull/54))
+- Fix outdated annotation
+- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
+- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
+- Python refactor ([#46](https://github.com/toolCHAINZ/jingle/pull/46))
+- Add feature flag ([#45](https://github.com/toolCHAINZ/jingle/pull/45))
+- Python rlib ([#44](https://github.com/toolCHAINZ/jingle/pull/44))
+- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
+- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
+- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))

--- a/jingle_python/Cargo.toml
+++ b/jingle_python/Cargo.toml
@@ -15,4 +15,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.24"
-jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.1.1"}
+jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.1.2" }

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.1.1...jingle_sleigh-v0.1.2) - 2025-07-10
+
+### Other
+
+- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
+- Bump ghidra to 11.4 ([#57](https://github.com/toolCHAINZ/jingle/pull/57))
+- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
+- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
+- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
+- Expose more structs ([#49](https://github.com/toolCHAINZ/jingle/pull/49))
+- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
+- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
+- Add missing cfg guard
+- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
+- API Cleanup ([#35](https://github.com/toolCHAINZ/jingle/pull/35))
+- Target ghidra 11.3 ([#32](https://github.com/toolCHAINZ/jingle/pull/32))
+- Merge dev changes ([#31](https://github.com/toolCHAINZ/jingle/pull/31))

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `jingle`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `jingle_python`: 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.1.1...jingle_sleigh-v0.1.2) - 2025-07-10

### Other

- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
- Bump ghidra to 11.4 ([#57](https://github.com/toolCHAINZ/jingle/pull/57))
- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
- Expose more structs ([#49](https://github.com/toolCHAINZ/jingle/pull/49))
- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
- Add missing cfg guard
- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
- API Cleanup ([#35](https://github.com/toolCHAINZ/jingle/pull/35))
- Target ghidra 11.3 ([#32](https://github.com/toolCHAINZ/jingle/pull/32))
- Merge dev changes ([#31](https://github.com/toolCHAINZ/jingle/pull/31))
</blockquote>

## `jingle`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.1.1...jingle-v0.1.2) - 2025-07-10

### Other

- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
- Use latest z3 ([#65](https://github.com/toolCHAINZ/jingle/pull/65))
- Add varnode covering logic ([#59](https://github.com/toolCHAINZ/jingle/pull/59))
- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
- Add method to get instructions from a block in python ([#55](https://github.com/toolCHAINZ/jingle/pull/55))
- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
- pub ctx
- Add some [Partial]Eq derives
- fmt
- Improved location concretization
- Extend Python Z3 Interop ([#51](https://github.com/toolCHAINZ/jingle/pull/51))
- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
- pub
- Add some methods
- fmt + clippy
- Add another display
- Add display => str
- More python varnode representation tweaks
- fmt + clippy
- Add iter impl
- Fix names
- Change iterator to not work specifically on BVs ([#50](https://github.com/toolCHAINZ/jingle/pull/50))
- Expose more structs ([#49](https://github.com/toolCHAINZ/jingle/pull/49))
- Python/Rust Conversion Trait ([#48](https://github.com/toolCHAINZ/jingle/pull/48))
- Change wrapping of pythong z3
- Pub instr
- Python refactor ([#46](https://github.com/toolCHAINZ/jingle/pull/46))
- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
- API Cleanup ([#35](https://github.com/toolCHAINZ/jingle/pull/35))
- Merge dev changes ([#31](https://github.com/toolCHAINZ/jingle/pull/31))
</blockquote>

## `jingle_python`

<blockquote>

## [0.1.1](https://github.com/toolCHAINZ/jingle/releases/tag/jingle_python-v0.1.1) - 2025-07-10

### Other

- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
- Add forgotten type annotation
- Fix python z3 import error ([#54](https://github.com/toolCHAINZ/jingle/pull/54))
- Fix outdated annotation
- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
- Python refactor ([#46](https://github.com/toolCHAINZ/jingle/pull/46))
- Add feature flag ([#45](https://github.com/toolCHAINZ/jingle/pull/45))
- Python rlib ([#44](https://github.com/toolCHAINZ/jingle/pull/44))
- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).