### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.1.3...jingle-v0.1.4) - 2025-07-16
+
+### Fixed
+
+- remove faulty logic and deprecate old interfaces ([#72](https://github.com/toolCHAINZ/jingle/pull/72))
+
 ## [0.1.3](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.1.2...jingle-v0.1.3) - 2025-07-16
 
 ### Fixed

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"
@@ -19,7 +19,7 @@ name = "jingle"
 required-features = ["bin_features"]
 
 [dependencies]
-jingle_sleigh = { path = "../jingle_sleigh", version = "0.1.3" }
+jingle_sleigh = { path = "../jingle_sleigh", version = "0.1.4" }
 z3 = "0.13"
 z3-sys = { version = "0.9", optional = true }
 thiserror = "2.0"

--- a/jingle_python/Cargo.toml
+++ b/jingle_python/Cargo.toml
@@ -15,4 +15,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.24"
-jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.1.3" }
+jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.1.4" }

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,12 +9,3 @@ name = "jingle_python"
 publish = false # disable `cargo publish` for `package_a`
 git_release_enable = false
 git_tag_enable = false
-
-[[package]]
-name = "jingle"
-version_group = "jingle"
-
-[[package]]
-name = "jingle_sleigh"
-version_group = "jingle"
-


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.1.3 -> 0.1.4
* `jingle`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `jingle_python`: 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.1.1...jingle_sleigh-v0.1.2) - 2025-07-10

### Other

- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
- Bump ghidra to 11.4 ([#57](https://github.com/toolCHAINZ/jingle/pull/57))
- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
- Expose more structs ([#49](https://github.com/toolCHAINZ/jingle/pull/49))
- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
- Add missing cfg guard
- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
- API Cleanup ([#35](https://github.com/toolCHAINZ/jingle/pull/35))
- Target ghidra 11.3 ([#32](https://github.com/toolCHAINZ/jingle/pull/32))
- Merge dev changes ([#31](https://github.com/toolCHAINZ/jingle/pull/31))
</blockquote>

## `jingle`

<blockquote>

## [0.1.4](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.1.3...jingle-v0.1.4) - 2025-07-16

### Fixed

- remove faulty logic and deprecate old interfaces ([#72](https://github.com/toolCHAINZ/jingle/pull/72))
</blockquote>

## `jingle_python`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/jingle/releases/tag/jingle_python-v0.1.1) - 2025-07-10

### Other

- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
- Add forgotten type annotation
- Fix python z3 import error ([#54](https://github.com/toolCHAINZ/jingle/pull/54))
- Fix outdated annotation
- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
- Python refactor ([#46](https://github.com/toolCHAINZ/jingle/pull/46))
- Add feature flag ([#45](https://github.com/toolCHAINZ/jingle/pull/45))
- Python rlib ([#44](https://github.com/toolCHAINZ/jingle/pull/44))
- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).