### PR TITLE
feat: add basic analysis

### DIFF
--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -30,6 +30,7 @@ confy = { version = "1.0.0", optional = true}
 hex = { version = "0.4" , optional = true}
 anyhow = { version = "1.0", optional = true }
 pyo3 = { version = "0.25", optional = true }
+petgraph = "0.8.2"
 
 [features]
 default = []

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -26,10 +26,10 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 clap = { version = "4.5", optional = true, features = ["derive"] }
-confy = { version = "0.6" , optional = true}
+confy = { version = "1.0.0", optional = true}
 hex = { version = "0.4" , optional = true}
 anyhow = { version = "1.0", optional = true }
-pyo3 = { version = "0.24", optional = true }
+pyo3 = { version = "0.25", optional = true }
 
 [features]
 default = []

--- a/jingle/src/analysis/cfg.rs
+++ b/jingle/src/analysis/cfg.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
+use crate::JingleContext;
+use crate::modeling::machine::MachineState;
+use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+use jingle_sleigh::PcodeOperation;
 use petgraph::Direction;
 use petgraph::graphmap::DiGraphMap;
+use std::collections::HashMap;
 use z3::ast::{Ast, Bool};
 use z3::{Model, Solver};
-use jingle_sleigh::PcodeOperation;
-use crate::JingleContext;
-use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
-use crate::modeling::machine::MachineState;
 
 pub struct PcodeCfg {
     graph: DiGraphMap<ConcretePcodeAddress, PcodeOperation>,

--- a/jingle/src/analysis/cpa/lattice/flat.rs
+++ b/jingle/src/analysis/cpa/lattice/flat.rs
@@ -20,7 +20,7 @@ impl<C: Display> Display for FlatLattice<C> {
         match self {
             FlatLattice::Value(a) => f
                 .debug_tuple("FlatLattice")
-                .field(&format_args!("{}", a))
+                .field(&format_args!("{a}"))
                 .finish(),
             FlatLattice::Top => write!(f, "FlatLattice(Top)"),
         }
@@ -32,7 +32,7 @@ impl<C: LowerHex> LowerHex for FlatLattice<C> {
         match self {
             FlatLattice::Value(a) => f
                 .debug_tuple("FlatLattice")
-                .field(&format_args!("{:x}", a))
+                .field(&format_args!("{a:x}"))
                 .finish(),
             FlatLattice::Top => write!(f, "FlatLattice(Top)"),
         }

--- a/jingle/src/analysis/cpa/lattice/flat.rs
+++ b/jingle/src/analysis/cpa/lattice/flat.rs
@@ -1,7 +1,7 @@
+use crate::analysis::cpa::lattice::JoinSemiLattice;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter, LowerHex};
 use std::hash::Hash;
-use crate::analysis::cpa::lattice::JoinSemiLattice;
 
 #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
 pub enum FlatLattice<C> {

--- a/jingle/src/analysis/cpa/lattice/flat.rs
+++ b/jingle/src/analysis/cpa/lattice/flat.rs
@@ -1,0 +1,107 @@
+use std::cmp::Ordering;
+use std::fmt::{Debug, Display, Formatter, LowerHex};
+use std::hash::Hash;
+use crate::analysis::cpa::lattice::JoinSemiLattice;
+
+#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
+pub enum FlatLattice<C> {
+    Value(C),
+    Top,
+}
+
+impl<C> From<C> for FlatLattice<C> {
+    fn from(value: C) -> Self {
+        FlatLattice::Value(value)
+    }
+}
+
+impl<C: Display> Display for FlatLattice<C> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FlatLattice::Value(a) => f
+                .debug_tuple("FlatLattice")
+                .field(&format_args!("{}", a))
+                .finish(),
+            FlatLattice::Top => write!(f, "FlatLattice(Top)"),
+        }
+    }
+}
+
+impl<C: LowerHex> LowerHex for FlatLattice<C> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FlatLattice::Value(a) => f
+                .debug_tuple("FlatLattice")
+                .field(&format_args!("{:x}", a))
+                .finish(),
+            FlatLattice::Top => write!(f, "FlatLattice(Top)"),
+        }
+    }
+}
+
+impl<C: PartialOrd + PartialEq + Clone> FlatLattice<C> {
+    pub fn is_top(&self) -> bool {
+        matches!(self, FlatLattice::Top)
+    }
+
+    pub fn value(&self) -> Option<&C> {
+        match self {
+            FlatLattice::Value(c) => Some(c),
+            FlatLattice::Top => None,
+        }
+    }
+}
+
+impl<C: PartialOrd + PartialEq + Clone> PartialOrd for FlatLattice<C> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (&self, &other) {
+            (Self::Top, Self::Top) => Some(Ordering::Equal),
+            (Self::Top, Self::Value(_)) => Some(Ordering::Greater),
+            (Self::Value(_), Self::Top) => Some(Ordering::Less),
+            (Self::Value(a), Self::Value(b)) => {
+                if a == b {
+                    Some(Ordering::Equal)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl<C: PartialOrd + Eq + Clone> JoinSemiLattice for FlatLattice<C> {
+    fn join(&mut self, other: &Self) {
+        match (&self, other) {
+            (Self::Top, _) => *self = Self::Top,
+            (_, Self::Top) => *self = Self::Top,
+            (Self::Value(a), Self::Value(b)) => {
+                if a == b {
+                    // do nothing
+                } else {
+                    *self = Self::Top
+                }
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analysis::cpa::lattice::flat::FlatLattice;
+
+    #[test]
+    pub fn test_flat_lattice() {
+        let val1 = FlatLattice::Value(4u64);
+        let val2 = FlatLattice::Value(5u64);
+        let top = FlatLattice::Top;
+        assert_eq!(val1, val1);
+        assert_eq!(val2, val2);
+        assert_eq!(top, top);
+        assert_ne!(val1, val2);
+        assert_ne!(val1, top);
+        assert!(top > val1);
+        assert!(top > val2);
+        assert!(val1.partial_cmp(&val2).is_none());
+        assert!(val2.partial_cmp(&val1).is_none());
+    }
+}

--- a/jingle/src/analysis/cpa/lattice/mod.rs
+++ b/jingle/src/analysis/cpa/lattice/mod.rs
@@ -1,0 +1,26 @@
+mod simple;
+
+pub trait JoinSemiLattice: Eq + PartialOrd {
+    fn join(&mut self, other: &Self);
+    // todo: add top method?
+    // fn is_top(&self) -> bool;
+}
+
+/// This trait exists to allow defining types that are
+/// "lattice-y" without requiring that they specify a Top element.
+/// Types implementing this trait can be used to construct
+/// an actual Lattice using [super::simple_lattice::SimpleLattice]
+pub trait PartialJoinSemiLattice: Eq + PartialOrd + Sized {
+    fn partial_join(&self, other: &Self) -> Option<Self>;
+}
+
+impl<S1, S2> JoinSemiLattice for (S1, S2)
+where
+    S1: JoinSemiLattice,
+    S2: JoinSemiLattice,
+{
+    fn join(&mut self, other: &Self) {
+        self.0.join(&other.0);
+        self.1.join(&other.1);
+    }
+}

--- a/jingle/src/analysis/cpa/lattice/mod.rs
+++ b/jingle/src/analysis/cpa/lattice/mod.rs
@@ -1,6 +1,6 @@
-pub mod simple;
-pub mod pcode;
 pub mod flat;
+pub mod pcode;
+pub mod simple;
 
 pub trait JoinSemiLattice: Eq + PartialOrd {
     fn join(&mut self, other: &Self);

--- a/jingle/src/analysis/cpa/lattice/mod.rs
+++ b/jingle/src/analysis/cpa/lattice/mod.rs
@@ -1,4 +1,6 @@
 pub mod simple;
+pub mod pcode;
+pub mod flat;
 
 pub trait JoinSemiLattice: Eq + PartialOrd {
     fn join(&mut self, other: &Self);

--- a/jingle/src/analysis/cpa/lattice/mod.rs
+++ b/jingle/src/analysis/cpa/lattice/mod.rs
@@ -1,4 +1,4 @@
-mod simple;
+pub mod simple;
 
 pub trait JoinSemiLattice: Eq + PartialOrd {
     fn join(&mut self, other: &Self);

--- a/jingle/src/analysis/cpa/lattice/pcode.rs
+++ b/jingle/src/analysis/cpa/lattice/pcode.rs
@@ -1,8 +1,8 @@
-use std::iter::{empty, once};
-use jingle_sleigh::PcodeOperation;
 use crate::analysis::cpa::lattice::flat::FlatLattice;
 use crate::analysis::cpa::state::{AbstractState, MergeOutcome};
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+use jingle_sleigh::PcodeOperation;
+use std::iter::{empty, once};
 
 pub type PcodeAddressLattice = FlatLattice<ConcretePcodeAddress>;
 

--- a/jingle/src/analysis/cpa/lattice/pcode.rs
+++ b/jingle/src/analysis/cpa/lattice/pcode.rs
@@ -1,0 +1,42 @@
+use std::iter::{empty, once};
+use jingle_sleigh::PcodeOperation;
+use crate::analysis::cpa::lattice::flat::FlatLattice;
+use crate::analysis::cpa::state::{AbstractState, MergeOutcome};
+use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+
+pub type PcodeAddressLattice = FlatLattice<ConcretePcodeAddress>;
+
+impl AbstractState for PcodeAddressLattice {
+    type SuccessorIter = Box<dyn Iterator<Item = Self>>;
+
+    fn merge(&mut self, other: &Self) -> MergeOutcome {
+        self.merge_sep(other)
+    }
+
+    fn stop<'a, T: Iterator<Item = &'a Self>>(&'a self, states: T) -> bool {
+        self.stop_sep(states)
+    }
+
+    fn transfer(&self, op: &PcodeOperation) -> Box<dyn Iterator<Item = Self>> {
+        match &self {
+            PcodeAddressLattice::Value(a) => match op {
+                PcodeOperation::Branch { input } => {
+                    Box::new(once(ConcretePcodeAddress::from(input.offset).into()))
+                }
+                PcodeOperation::CBranch { input0, .. } => {
+                    let dest = ConcretePcodeAddress::resolve_from_varnode(input0, *a);
+                    let fallthrough = a.next_pcode();
+                    Box::new(once(dest.into()).chain(once(fallthrough.into())))
+                }
+                PcodeOperation::Call { .. } | PcodeOperation::CallOther { .. } => {
+                    Box::new(once(a.next_pcode().into()))
+                }
+                PcodeOperation::Return { .. }
+                | PcodeOperation::CallInd { .. }
+                | PcodeOperation::BranchInd { .. } => Box::new(empty()),
+                _ => Box::new(once(a.next_pcode().into())),
+            },
+            PcodeAddressLattice::Top => Box::new(once(PcodeAddressLattice::Top)),
+        }
+    }
+}

--- a/jingle/src/analysis/cpa/lattice/simple.rs
+++ b/jingle/src/analysis/cpa/lattice/simple.rs
@@ -1,5 +1,5 @@
-use std::cmp::Ordering;
 use crate::analysis::cpa::lattice::{JoinSemiLattice, PartialJoinSemiLattice};
+use std::cmp::Ordering;
 
 #[derive(PartialEq, Eq)]
 pub enum SimpleLattice<C> {

--- a/jingle/src/analysis/cpa/lattice/simple.rs
+++ b/jingle/src/analysis/cpa/lattice/simple.rs
@@ -1,0 +1,32 @@
+use std::cmp::Ordering;
+use crate::analysis::cpa::lattice::{JoinSemiLattice, PartialJoinSemiLattice};
+
+#[derive(PartialEq, Eq)]
+pub enum SimpleLattice<C> {
+    Value(C),
+    Top,
+}
+
+impl<C: PartialJoinSemiLattice> PartialOrd for SimpleLattice<C> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (Self::Top, Self::Top) => Some(Ordering::Equal),
+            (Self::Top, _) => Some(Ordering::Greater),
+            (_, Self::Top) => Some(Ordering::Less),
+            (Self::Value(a), Self::Value(b)) => a.partial_cmp(b),
+        }
+    }
+}
+
+impl<C: PartialJoinSemiLattice> JoinSemiLattice for SimpleLattice<C> {
+    fn join(&mut self, other: &Self) {
+        match (&self, &other) {
+            (Self::Top, _) => (),
+            (_, Self::Top) => *self = Self::Top,
+            (Self::Value(a), Self::Value(b)) => match a.partial_join(b) {
+                None => *self = Self::Top,
+                Some(c) => *self = Self::Value(c),
+            },
+        }
+    }
+}

--- a/jingle/src/analysis/cpa/mod.rs
+++ b/jingle/src/analysis/cpa/mod.rs
@@ -1,5 +1,5 @@
-mod lattice;
-mod state;
+pub mod lattice;
+pub mod state;
 
 use crate::analysis::cpa::state::AbstractState;
 use std::collections::VecDeque;

--- a/jingle/src/analysis/cpa/mod.rs
+++ b/jingle/src/analysis/cpa/mod.rs
@@ -20,6 +20,7 @@ unreached abstract state, indicating a fixed point over the given domain.
 As the abstract states form a lattice, this algorithm is guaranteed to terminate on any finite
 set of abstract states.
 */
+#[expect(unused)]
 pub trait ConfigurableProgramAnalysis {
     /// An abstract state. Usually (but not necessarily) represents a single program location.
     type State: AbstractState + Debug;

--- a/jingle/src/analysis/cpa/mod.rs
+++ b/jingle/src/analysis/cpa/mod.rs
@@ -1,0 +1,60 @@
+mod state;
+mod lattice;
+
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use crate::analysis::cpa::state::AbstractState;
+
+/**
+A trait representing Configurable Program Analysis, a tunable unified framework for
+dataflow and model checking algorithms. This implementation is based on the presentation of
+CPA contained in Chapter 16 of
+[The Handbook of Model Checking](https://link.springer.com/book/10.1007/978-3-319-10575-8)
+
+CPA operates on abstract states, which are required to form a Lattice, specifically a
+[JoinSemiLattice] (which requires a [join](JoinSemiLattice::join) operation). CPA applies
+concrete transitions to abstract states, producing more abstract states. These states can
+be merged when control flow merges (potentially losing information) or kept separate, providing
+a large degree of flexibility. The algorithm terminates when no reached abstract state produces any
+unreached abstract state, indicating a fixed point over the given domain.
+As the abstract states form a lattice, this algorithm is guaranteed to terminate on any finite
+set of abstract states.
+*/
+pub trait ConfigurableProgramAnalysis {
+    /// An abstract state. Usually (but not necessarily) represents a single program location.
+    type State: AbstractState + Debug;
+
+    /// An iterator type for successor states generated from an abstract state
+    type Iter: Iterator<Item = Self::State>;
+
+    /// Generates an iterator of successor states for a given abstract state. This represents the
+    /// transition relation of CPA. While this trait makes no reference to this transition relation
+    /// or the types involved in it, it is assumed that an implemented analysis will contain the
+    /// data necessary to query the transition relation for successor states.
+    fn successor_states(&mut self, state: &Self::State) -> Self::Iter;
+
+    /// The CPA algorithm. Implementors should not need to customize this function.
+    ///
+    /// Returns an iterator over abstract states reached from the initial abstract state.
+    fn run_cpa(&mut self, initial: &Self::State) -> impl Iterator<Item = Self::State> {
+        let mut waitlist: VecDeque<Self::State> = VecDeque::new();
+        let mut reached: VecDeque<Self::State> = VecDeque::new();
+        waitlist.push_front(initial.clone());
+        reached.push_front(initial.clone());
+        while let Some(state) = waitlist.pop_front() {
+            for dest_state in self.successor_states(&state) {
+                for reached_state in reached.iter_mut() {
+                    if reached_state.merge(&dest_state).merged() {
+                        waitlist.push_back(reached_state.clone());
+                    }
+                }
+
+                if !dest_state.stop(reached.iter()) {
+                    waitlist.push_back(dest_state.clone());
+                    reached.push_back(dest_state.clone());
+                }
+            }
+        }
+        reached.into_iter()
+    }
+}

--- a/jingle/src/analysis/cpa/mod.rs
+++ b/jingle/src/analysis/cpa/mod.rs
@@ -1,9 +1,9 @@
-mod state;
 mod lattice;
+mod state;
 
+use crate::analysis::cpa::state::AbstractState;
 use std::collections::VecDeque;
 use std::fmt::Debug;
-use crate::analysis::cpa::state::AbstractState;
 
 /**
 A trait representing Configurable Program Analysis, a tunable unified framework for

--- a/jingle/src/analysis/cpa/mod.rs
+++ b/jingle/src/analysis/cpa/mod.rs
@@ -20,7 +20,6 @@ unreached abstract state, indicating a fixed point over the given domain.
 As the abstract states form a lattice, this algorithm is guaranteed to terminate on any finite
 set of abstract states.
 */
-#[expect(unused)]
 pub trait ConfigurableProgramAnalysis {
     /// An abstract state. Usually (but not necessarily) represents a single program location.
     type State: AbstractState + Debug;

--- a/jingle/src/analysis/cpa/state.rs
+++ b/jingle/src/analysis/cpa/state.rs
@@ -13,7 +13,6 @@ impl MergeOutcome {
     }
 }
 
-#[expect(unused)]
 pub trait AbstractState: JoinSemiLattice + Clone {
     type SuccessorIter: Iterator<Item = Self>;
     /// Determines how two abstract states should be merged. Rather than consuming states

--- a/jingle/src/analysis/cpa/state.rs
+++ b/jingle/src/analysis/cpa/state.rs
@@ -1,5 +1,5 @@
-use jingle_sleigh::PcodeOperation;
 use crate::analysis::cpa::lattice::JoinSemiLattice;
+use jingle_sleigh::PcodeOperation;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MergeOutcome {

--- a/jingle/src/analysis/cpa/state.rs
+++ b/jingle/src/analysis/cpa/state.rs
@@ -1,0 +1,64 @@
+use jingle_sleigh::PcodeOperation;
+use crate::analysis::cpa::lattice::JoinSemiLattice;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MergeOutcome {
+    NoOp,
+    Merged,
+}
+
+impl MergeOutcome {
+    pub fn merged(&self) -> bool {
+        matches!(self, MergeOutcome::Merged)
+    }
+}
+
+pub trait AbstractState: JoinSemiLattice + Clone {
+    type SuccessorIter: Iterator<Item = Self>;
+    /// Determines how two abstract states should be merged. Rather than consuming states
+    /// and returning a new state, we mutate the first state argument. In the context of
+    /// CPA, the first state should be the state from the _reached_ list, NOT the new/merged
+    /// state.
+    ///
+    /// Implementations of this function must ENSURE (the compiler can't help here) that
+    /// the mutated State is
+    /// [Greater](std::cmp::Ordering::Greater) or [Equal](std::cmp::Ordering::Equal)
+    /// than it was going in. Violating this is a logic error that may make CPA not terminate.
+    fn merge(&mut self, other: &Self) -> MergeOutcome;
+
+    /// A naive "cartesian" merge of two states, replacing `existing_state` with their
+    /// Least Upper Bound.
+    fn merge_join(&mut self, new_state: &Self) -> MergeOutcome {
+        if self == new_state {
+            MergeOutcome::NoOp
+        } else {
+            self.join(new_state);
+            MergeOutcome::Merged
+        }
+    }
+
+    /// A naive "separate" merge of two states, simply duplicating `existing_state`.
+    fn merge_sep(&mut self, _: &Self) -> MergeOutcome {
+        MergeOutcome::NoOp
+    }
+
+    /// Determines whether the given abstract state is covered by the set of reached
+    /// abstract states. If it is not covered, this returns [false], indicating that this
+    /// state should be added to CPA's waitlist. Otherwise, nothing is done, effectively terminating
+    /// the current "branch" of analysis.
+    ///
+    /// Determining whether a state "covers" another may be done piecewise or by combining reached
+    /// states, and is usually done with respect to the [JoinSemiLattice] defined over abstract states.
+    fn stop<'a, T: Iterator<Item = &'a Self>>(&'a self, states: T) -> bool;
+
+    /// A naive implementation of [stop] which checks for state covering in a piecewise manner.
+    fn stop_sep<'a, T: Iterator<Item = &'a Self>>(&'a self, mut states: T) -> bool {
+        states.any(|s| self <= s)
+    }
+
+    /// Given a pcode operation, returns an iterator of successor states.
+    /// Decided to make this an iterator to allow making the state structures simpler
+    /// (e.g. a resolved indirect jump could return an iterator of locations instead of
+    /// having a special "the location is one in this list" variant
+    fn transfer(&self, opcode: &PcodeOperation) -> Self::SuccessorIter;
+}

--- a/jingle/src/analysis/cpa/state.rs
+++ b/jingle/src/analysis/cpa/state.rs
@@ -3,16 +3,19 @@ use jingle_sleigh::PcodeOperation;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MergeOutcome {
+    #[expect(unused)]
     NoOp,
     Merged,
 }
 
 impl MergeOutcome {
+    #[expect(unused)]
     pub fn merged(&self) -> bool {
         matches!(self, MergeOutcome::Merged)
     }
 }
 
+#[expect(unused)]
 pub trait AbstractState: JoinSemiLattice + Clone {
     type SuccessorIter: Iterator<Item = Self>;
     /// Determines how two abstract states should be merged. Rather than consuming states

--- a/jingle/src/analysis/cpa/state.rs
+++ b/jingle/src/analysis/cpa/state.rs
@@ -3,13 +3,11 @@ use jingle_sleigh::PcodeOperation;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MergeOutcome {
-    #[expect(unused)]
     NoOp,
     Merged,
 }
 
 impl MergeOutcome {
-    #[expect(unused)]
     pub fn merged(&self) -> bool {
         matches!(self, MergeOutcome::Merged)
     }

--- a/jingle/src/analysis/direct_location/mod.rs
+++ b/jingle/src/analysis/direct_location/mod.rs
@@ -1,6 +1,3 @@
-use std::iter::{empty, once, Chain, Once};
-use petgraph::graphmap::DiGraphMap;
-use jingle_sleigh::PcodeOperation;
 use crate::analysis::Analysis;
 use crate::analysis::cfg::PcodeCfg;
 use crate::analysis::cpa::ConfigurableProgramAnalysis;
@@ -9,6 +6,9 @@ use crate::analysis::cpa::state::AbstractState;
 use crate::analysis::direct_location::SuccessorIterator::{Conditional, Single};
 use crate::analysis::pcode_store::PcodeStore;
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+use jingle_sleigh::PcodeOperation;
+use petgraph::graphmap::DiGraphMap;
+use std::iter::{Chain, Once, empty, once};
 
 pub enum SuccessorIterator {
     Terminate,

--- a/jingle/src/analysis/direct_location/mod.rs
+++ b/jingle/src/analysis/direct_location/mod.rs
@@ -1,0 +1,95 @@
+use std::iter::{empty, once, Chain, Once};
+use petgraph::graphmap::DiGraphMap;
+use jingle_sleigh::PcodeOperation;
+use crate::analysis::Analysis;
+use crate::analysis::cfg::PcodeCfg;
+use crate::analysis::cpa::ConfigurableProgramAnalysis;
+use crate::analysis::cpa::lattice::pcode::PcodeAddressLattice;
+use crate::analysis::cpa::state::AbstractState;
+use crate::analysis::direct_location::SuccessorIterator::{Conditional, Single};
+use crate::analysis::pcode_store::PcodeStore;
+use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+
+pub enum SuccessorIterator {
+    Terminate,
+    Single(Once<PcodeAddressLattice>),
+    Conditional(Chain<Once<PcodeAddressLattice>, Once<PcodeAddressLattice>>),
+}
+
+impl Iterator for SuccessorIterator {
+    type Item = PcodeAddressLattice;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Terminate => None,
+            Single(a) => a.next(),
+            Conditional(b) => b.next(),
+        }
+    }
+}
+
+pub struct DirectLocationCPA<T> {
+    pcode: T,
+    pub graph: DiGraphMap<ConcretePcodeAddress, PcodeOperation>,
+}
+
+pub struct DirectLocationAnalysis;
+
+impl<T: PcodeStore> DirectLocationCPA<T> {
+    pub fn new(pcode: T) -> Self {
+        Self {
+            pcode,
+            graph: Default::default(),
+        }
+    }
+
+    pub fn pcode_at(
+        &self,
+        state: &<DirectLocationCPA<T> as ConfigurableProgramAnalysis>::State,
+    ) -> Option<PcodeOperation> {
+        state.value().and_then(|a| self.pcode.get_pcode_op_at(*a))
+    }
+}
+impl<T: PcodeStore> ConfigurableProgramAnalysis for DirectLocationCPA<T> {
+    type State = PcodeAddressLattice;
+
+    type Iter = Box<dyn Iterator<Item = Self::State>>;
+
+    fn successor_states(&mut self, state: &Self::State) -> Self::Iter {
+        match state {
+            PcodeAddressLattice::Value(a) => {
+                if let Some(op) = self.pcode.get_pcode_op_at(*a) {
+                    let nd = self.graph.add_node(*a);
+                    let iter: Vec<_> = state
+                        .transfer(&op)
+                        .inspect(|f| {
+                            if let PcodeAddressLattice::Value(f) = f {
+                                let nd2 = self.graph.add_node(*f);
+                                self.graph.add_edge(nd, nd2, op.clone());
+                            }
+                        })
+                        .collect();
+                    Box::new(iter.into_iter())
+                } else {
+                    Box::new(empty())
+                }
+            }
+            PcodeAddressLattice::Top => Box::new(once(PcodeAddressLattice::Top)),
+        }
+    }
+}
+
+impl Analysis for DirectLocationAnalysis {
+    type Output = PcodeCfg;
+    type Input = ConcretePcodeAddress;
+
+    fn run<T: PcodeStore>(&mut self, store: T, initial_state: Self::Input) -> Self::Output {
+        let lattice = PcodeAddressLattice::Value(initial_state);
+        let mut cpa = DirectLocationCPA::new(store);
+        let _ = cpa.run_cpa(&lattice);
+        PcodeCfg::new(cpa.graph.clone(), initial_state)
+    }
+    fn make_initial_state(&self, addr: ConcretePcodeAddress) -> Self::Input {
+        addr
+    }
+}

--- a/jingle/src/analysis/mod.rs
+++ b/jingle/src/analysis/mod.rs
@@ -1,7 +1,5 @@
 use crate::analysis::pcode_store::{EntryPoint, PcodeStore};
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
-use jingle_sleigh::context::loaded::LoadedSleighContext;
-use jingle_sleigh::{ArchInfoProvider, PcodeOperation, VarNode};
 
 mod cpa;
 pub mod pcode_store;
@@ -24,7 +22,6 @@ pub trait Analysis {
     fn run<T: PcodeStore>(&mut self, store: T, initial_state: Self::Input) -> Self::Output;
     /// Given an initial [ConcretePcodeAddress], derive the [Input](Self::Input) state for
     /// a CPA
-
     fn make_initial_state(&self, addr: ConcretePcodeAddress) -> Self::Input;
 }
 

--- a/jingle/src/analysis/mod.rs
+++ b/jingle/src/analysis/mod.rs
@@ -1,7 +1,7 @@
 use crate::analysis::pcode_store::{EntryPoint, PcodeStore};
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 
-mod cpa;
+pub mod cpa;
 pub mod pcode_store;
 pub mod varnode;
 

--- a/jingle/src/analysis/mod.rs
+++ b/jingle/src/analysis/mod.rs
@@ -4,6 +4,8 @@ use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 pub mod cpa;
 pub mod pcode_store;
 pub mod varnode;
+pub mod direct_location;
+pub mod cfg;
 
 /// A compatibility wrapper around [CPAs]. The intent here is to provide some structure
 /// for running and combining CPAs. The output of the CPA is often not exactly in a format

--- a/jingle/src/analysis/mod.rs
+++ b/jingle/src/analysis/mod.rs
@@ -1,1 +1,47 @@
+use jingle_sleigh::context::loaded::LoadedSleighContext;
+use jingle_sleigh::{ArchInfoProvider, PcodeOperation, VarNode};
+use crate::analysis::pcode_store::{EntryPoint, PcodeStore};
+use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+
 pub mod varnode;
+pub mod pcode_store;
+mod cpa;
+
+/// A compatibility wrapper around [CPAs]. The intent here is to provide some structure
+/// for running and combining CPAs. The output of the CPA is often not exactly in a format
+/// that is easily used, and they can require some setup. This trait allows for specifying
+/// a way to define the CPA's input (assuming a [PcodeCfg](crate::cfg::PcodeCfg), indexed by
+/// [ConcretePcodeAddress]es), and process its output. A PCodeCFG can then run any type
+/// implementing Analysis without a lot of wrangling stuff around. Analyses can also output
+/// new PCodeCfgs or related types with additional information.
+pub trait Analysis {
+    /// The output type of the analysis; may or may not be the CPA's result
+    type Output;
+    /// The input type of the analysis, must be derivable from a [ConcretePcodeAddress] and
+    /// any state in the type implementing [Analysis]
+    type Input;
+    /// Run the [Analysis] and return its [Output](Self::Output)
+    fn run<T: PcodeStore>(&mut self, store: T, initial_state: Self::Input) -> Self::Output;
+    /// Given an initial [ConcretePcodeAddress], derive the [Input](Self::Input) state for
+    /// a CPA
+
+    fn make_initial_state(&self, addr: ConcretePcodeAddress) -> Self::Input;
+}
+
+pub trait AnalyzableBase: PcodeStore + Sized {
+    fn run_analysis_at<T: Analysis, S: Into<ConcretePcodeAddress>>(&self, entry: S, mut t: T) -> T::Output {
+        let entry = t.make_initial_state(entry.into());
+        t.run(self, entry)
+    }
+}
+
+pub trait AnalyzableEntry: PcodeStore + EntryPoint + Sized{
+    fn run_analysis<T: Analysis>(&self, mut t: T) -> T::Output {
+        let entry = t.make_initial_state(self.get_entry());
+        t.run(self, entry)
+    }
+}
+
+
+impl<T: PcodeStore> AnalyzableBase for T {}
+impl <T: PcodeStore + EntryPoint> AnalyzableEntry for T {}

--- a/jingle/src/analysis/mod.rs
+++ b/jingle/src/analysis/mod.rs
@@ -1,11 +1,11 @@
 use crate::analysis::pcode_store::{EntryPoint, PcodeStore};
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 
+pub mod cfg;
 pub mod cpa;
+pub mod direct_location;
 pub mod pcode_store;
 pub mod varnode;
-pub mod direct_location;
-pub mod cfg;
 
 /// A compatibility wrapper around [CPAs]. The intent here is to provide some structure
 /// for running and combining CPAs. The output of the CPA is often not exactly in a format

--- a/jingle/src/analysis/mod.rs
+++ b/jingle/src/analysis/mod.rs
@@ -1,11 +1,11 @@
-use jingle_sleigh::context::loaded::LoadedSleighContext;
-use jingle_sleigh::{ArchInfoProvider, PcodeOperation, VarNode};
 use crate::analysis::pcode_store::{EntryPoint, PcodeStore};
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+use jingle_sleigh::context::loaded::LoadedSleighContext;
+use jingle_sleigh::{ArchInfoProvider, PcodeOperation, VarNode};
 
-pub mod varnode;
-pub mod pcode_store;
 mod cpa;
+pub mod pcode_store;
+pub mod varnode;
 
 /// A compatibility wrapper around [CPAs]. The intent here is to provide some structure
 /// for running and combining CPAs. The output of the CPA is often not exactly in a format
@@ -29,19 +29,22 @@ pub trait Analysis {
 }
 
 pub trait AnalyzableBase: PcodeStore + Sized {
-    fn run_analysis_at<T: Analysis, S: Into<ConcretePcodeAddress>>(&self, entry: S, mut t: T) -> T::Output {
+    fn run_analysis_at<T: Analysis, S: Into<ConcretePcodeAddress>>(
+        &self,
+        entry: S,
+        mut t: T,
+    ) -> T::Output {
         let entry = t.make_initial_state(entry.into());
         t.run(self, entry)
     }
 }
 
-pub trait AnalyzableEntry: PcodeStore + EntryPoint + Sized{
+pub trait AnalyzableEntry: PcodeStore + EntryPoint + Sized {
     fn run_analysis<T: Analysis>(&self, mut t: T) -> T::Output {
         let entry = t.make_initial_state(self.get_entry());
         t.run(self, entry)
     }
 }
 
-
 impl<T: PcodeStore> AnalyzableBase for T {}
-impl <T: PcodeStore + EntryPoint> AnalyzableEntry for T {}
+impl<T: PcodeStore + EntryPoint> AnalyzableEntry for T {}

--- a/jingle/src/analysis/pcode_store.rs
+++ b/jingle/src/analysis/pcode_store.rs
@@ -1,19 +1,16 @@
+use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 use jingle_sleigh::context::loaded::LoadedSleighContext;
 use jingle_sleigh::{ArchInfoProvider, PcodeOperation, VarNode};
-use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 
 pub trait PcodeStore {
     fn get_pcode_op_at(&self, addr: ConcretePcodeAddress) -> Option<PcodeOperation>;
-
 }
 
-pub trait EntryPoint{
+pub trait EntryPoint {
     fn get_entry(&self) -> ConcretePcodeAddress;
 }
 
-
-impl<'a> PcodeStore for LoadedSleighContext<'a>{
-
+impl<'a> PcodeStore for LoadedSleighContext<'a> {
     fn get_pcode_op_at(&self, addr: ConcretePcodeAddress) -> Option<PcodeOperation> {
         let instr = self.instruction_at(addr.machine())?;
         if addr.pcode() as usize == instr.ops.len() {

--- a/jingle/src/analysis/pcode_store.rs
+++ b/jingle/src/analysis/pcode_store.rs
@@ -1,0 +1,37 @@
+use jingle_sleigh::context::loaded::LoadedSleighContext;
+use jingle_sleigh::{ArchInfoProvider, PcodeOperation, VarNode};
+use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
+
+pub trait PcodeStore {
+    fn get_pcode_op_at(&self, addr: ConcretePcodeAddress) -> Option<PcodeOperation>;
+
+}
+
+pub trait EntryPoint{
+    fn get_entry(&self) -> ConcretePcodeAddress;
+}
+
+
+impl<'a> PcodeStore for LoadedSleighContext<'a>{
+
+    fn get_pcode_op_at(&self, addr: ConcretePcodeAddress) -> Option<PcodeOperation> {
+        let instr = self.instruction_at(addr.machine())?;
+        if addr.pcode() as usize == instr.ops.len() {
+            Some(PcodeOperation::Branch {
+                input: VarNode {
+                    space_index: self.get_code_space_idx(),
+                    offset: addr.machine() + instr.length as u64,
+                    size: 1,
+                },
+            })
+        } else {
+            instr.ops.get(addr.pcode() as usize).cloned()
+        }
+    }
+}
+
+impl<T: PcodeStore> PcodeStore for &T {
+    fn get_pcode_op_at(&self, addr: ConcretePcodeAddress) -> Option<PcodeOperation> {
+        (*self).get_pcode_op_at(addr)
+    }
+}

--- a/jingle_python/Cargo.toml
+++ b/jingle_python/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["cdylib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-pyo3 = "0.24"
+pyo3 = "0.25"
 jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.1.4" }

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [dependencies.pyo3]
-version = "0.24.0"
+version = "0.25"
 optional = true
 
 [dependencies]

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -27,9 +27,9 @@ optional = true
 [dependencies]
 cxx = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.1"
 thiserror = { version = "2.0", features = [] }
-object = { version = "0.36", optional = true }
+object = { version = "0.37.1", optional = true }
 tracing = "0.1"
 
 [build-dependencies]

--- a/jingle_sleigh/src/context/builder/language_def.rs
+++ b/jingle_sleigh/src/context/builder/language_def.rs
@@ -15,31 +15,44 @@ pub enum SleighEndian {
 #[expect(unused)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct Compiler {
+    #[serde(rename = "@name")]
     pub name: String,
+    #[serde(rename = "@spec")]
     pub spec: String,
+    #[serde(rename = "@id")]
     pub id: String,
 }
 
 #[expect(unused)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct ExternalName {
+    #[serde(rename = "@tool")]
     pub tool: String,
+    #[serde(rename = "@name")]
     pub name: String,
 }
 
 #[expect(unused)]
 #[derive(Clone, Debug, Deserialize)]
-pub struct LanguageDefinition {
+#[serde(rename = "language")]
+pub struct Language {
+    #[serde(rename = "@processor")]
     pub processor: String,
+    #[serde(rename = "@endian")]
     pub endian: SleighEndian,
+    #[serde(rename = "@size")]
+    pub size: String,
+    #[serde(rename = "@variant")]
     pub variant: String,
+    #[serde(rename = "@version")]
     pub version: String,
-    #[serde(rename = "slafile")]
+    #[serde(rename = "@slafile")]
     pub sla_file: PathBuf,
-    #[serde(rename = "processorspec")]
+    #[serde(rename = "@processorspec")]
     pub processor_spec: PathBuf,
-    #[serde(rename = "manualindexfile")]
+    #[serde(rename = "@manualindexfile")]
     pub manual_index_file: Option<PathBuf>,
+    #[serde(rename = "@id")]
     pub id: String,
     pub description: String,
     pub compiler: Vec<Compiler>,
@@ -49,11 +62,11 @@ pub struct LanguageDefinition {
 #[derive(Debug, Deserialize)]
 #[serde(rename = "language_definitions")]
 struct LanguageDefinitions {
-    #[serde(rename = "$value")]
-    pub language_definitions: Vec<LanguageDefinition>,
+    #[serde(rename = "#content")]
+    pub language_definitions: Vec<Language>,
 }
 
-pub(super) fn parse_ldef(path: &Path) -> Result<Vec<LanguageDefinition>, JingleSleighError> {
+pub(super) fn parse_ldef(path: &Path) -> Result<Vec<Language>, JingleSleighError> {
     let file = File::open(path).map_err(|_| LanguageSpecRead)?;
     let def: LanguageDefinitions = serde_xml_rs::from_reader(file)?;
     Ok(def.language_definitions)
@@ -61,7 +74,7 @@ pub(super) fn parse_ldef(path: &Path) -> Result<Vec<LanguageDefinition>, JingleS
 
 #[cfg(test)]
 mod tests {
-    use crate::context::builder::language_def::LanguageDefinitions;
+    use crate::context::builder::language_def::{LanguageDefinitions};
     use serde_xml_rs::from_str;
     use std::fs::File;
     use std::io::Read;

--- a/jingle_sleigh/src/context/builder/language_def.rs
+++ b/jingle_sleigh/src/context/builder/language_def.rs
@@ -74,7 +74,7 @@ pub(super) fn parse_ldef(path: &Path) -> Result<Vec<Language>, JingleSleighError
 
 #[cfg(test)]
 mod tests {
-    use crate::context::builder::language_def::{LanguageDefinitions};
+    use crate::context::builder::language_def::LanguageDefinitions;
     use serde_xml_rs::from_str;
     use std::fs::File;
     use std::io::Read;

--- a/jingle_sleigh/src/context/builder/mod.rs
+++ b/jingle_sleigh/src/context/builder/mod.rs
@@ -26,7 +26,9 @@ impl SleighContextBuilder {
     }
     #[instrument(skip_all, fields(%id))]
     pub fn build(&self, id: &str) -> Result<SleighContext, JingleSleighError> {
-        let (lang, path) = self.get_language(id).ok_or(InvalidLanguageId(id.to_string()))?;
+        let (lang, path) = self
+            .get_language(id)
+            .ok_or(InvalidLanguageId(id.to_string()))?;
         let mut context = SleighContext::new(lang, path)?;
         event!(Level::INFO, "Created sleigh context");
         let pspec_path = path.join(&lang.processor_spec);

--- a/jingle_sleigh/src/context/builder/processor_spec.rs
+++ b/jingle_sleigh/src/context/builder/processor_spec.rs
@@ -7,16 +7,18 @@ use std::path::Path;
 #[derive(Debug, Deserialize)]
 #[serde(rename = "context_set")]
 pub struct ContextSet {
+    #[serde(rename = "@name")]
     pub name: String,
-    #[serde(rename = "val")]
+    #[serde(rename = "@val")]
     pub value: String,
 }
 #[expect(unused)]
 #[derive(Debug, Deserialize)]
 #[serde(rename = "context_set")]
 pub struct ContextSetSpace {
+    #[serde(rename = "@space")]
     pub space: String,
-    #[serde(rename = "$value")]
+    #[serde(rename = "#content")]
     pub sets: Vec<ContextSet>,
 }
 

--- a/jingle_sleigh/src/context/image/gimli.rs
+++ b/jingle_sleigh/src/context/image/gimli.rs
@@ -196,7 +196,10 @@ pub fn load_with_gimli<'a, P: AsRef<Path>, P2: AsRef<Path> + Debug>(
     let data = fs::read(p.as_ref()).map_err(|_| JingleSleighError::ImageLoadError)?;
     let f = object::File::parse(data.as_slice()).map_err(|_| JingleSleighError::ImageLoadError)?;
     let owned = OwnedFile::new(&f)?;
-    let arch = map_gimli_architecture(&f).ok_or(JingleSleighError::InvalidLanguageId(format!("{:?} (gimli)", f.architecture())))?;
+    let arch = map_gimli_architecture(&f).ok_or(JingleSleighError::InvalidLanguageId(format!(
+        "{:?} (gimli)",
+        f.architecture()
+    )))?;
     let sleigh = SleighContextBuilder::load_ghidra_installation(ghidra_path)?.build(arch)?;
     let loaded = sleigh.initialize_with_image(owned)?;
     Ok(loaded)

--- a/jingle_sleigh/src/context/image/gimli.rs
+++ b/jingle_sleigh/src/context/image/gimli.rs
@@ -196,7 +196,7 @@ pub fn load_with_gimli<'a, P: AsRef<Path>, P2: AsRef<Path> + Debug>(
     let data = fs::read(p.as_ref()).map_err(|_| JingleSleighError::ImageLoadError)?;
     let f = object::File::parse(data.as_slice()).map_err(|_| JingleSleighError::ImageLoadError)?;
     let owned = OwnedFile::new(&f)?;
-    let arch = map_gimli_architecture(&f).ok_or(JingleSleighError::InvalidLanguageId)?;
+    let arch = map_gimli_architecture(&f).ok_or(JingleSleighError::InvalidLanguageId(format!("{:?} (gimli)", f.architecture())))?;
     let sleigh = SleighContextBuilder::load_ghidra_installation(ghidra_path)?.build(arch)?;
     let loaded = sleigh.initialize_with_image(owned)?;
     Ok(loaded)

--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -12,7 +12,7 @@ use crate::space::SpaceInfo;
 pub use builder::SleighContextBuilder;
 
 use crate::JingleSleighError::{ImageLoadError, SleighCompilerMutexError};
-use crate::context::builder::language_def::LanguageDefinition;
+use crate::context::builder::language_def::Language;
 use crate::context::image::ImageProvider;
 use crate::context::loaded::LoadedSleighContext;
 use crate::ffi::context_ffi::CTX_BUILD_MUTEX;
@@ -72,7 +72,7 @@ impl ArchInfoProvider for SleighContext {
 
 impl SleighContext {
     pub(crate) fn new<T: AsRef<Path>>(
-        language_def: &LanguageDefinition,
+        language_def: &Language,
         base_path: T,
     ) -> Result<Self, JingleSleighError> {
         let path = base_path.as_ref().join(&language_def.sla_file);

--- a/jingle_sleigh/src/error.rs
+++ b/jingle_sleigh/src/error.rs
@@ -15,8 +15,8 @@ pub enum JingleSleighError {
     #[error("failed to parse sleigh language definition")]
     LanguageSpecParse(#[from] serde_xml_rs::Error),
     /// The user provided a sleigh language ID that has not been loaded
-    #[error("that's not a valid language id")]
-    InvalidLanguageId,
+    #[error("Could not find sleigh language with ID: {0}")]
+    InvalidLanguageId(String),
     /// Attempted to initialize sleigh but something went wrong
     #[error("Something went wrong putting bytes into sleigh: {0}")]
     SleighInitError(String),


### PR DESCRIPTION
This adds in code for:

* A basic CPA-style analysis framework (lattices, abstract states, fixed point computations over pcode-graphs)
* Some adapter traits to easily call CPA analyses
* A simple Location analysis that does not follow indirect branches. Suitable for finding the edges of simple function control-flow graphs purely by interpreting p-code.

More analyses to come!