### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.2.6...jingle-v0.2.7) - 2025-09-17
+
+### Added
+
+- add bounded visitor analysis ([#77](https://github.com/toolCHAINZ/jingle/pull/77))
+
+### Other
+
+- bump pyo3 ([#92](https://github.com/toolCHAINZ/jingle/pull/92))
+
 ## [0.2.6](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.2.5...jingle-v0.2.6) - 2025-09-14
 
 ### Other

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"
@@ -19,7 +19,7 @@ name = "jingle"
 required-features = ["bin"]
 
 [dependencies]
-jingle_sleigh = { path = "../jingle_sleigh", version = "0.2.3" }
+jingle_sleigh = { path = "../jingle_sleigh", version = "0.2.4" }
 z3 = { version = "0.18.2" }
 z3-sys = { version = "0.9.9", optional = true }
 thiserror = "2.0"

--- a/jingle_python/Cargo.toml
+++ b/jingle_python/Cargo.toml
@@ -15,4 +15,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.26"
-jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.2.6" }
+jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.2.7" }

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.2.3...jingle_sleigh-v0.2.4) - 2025-09-17
+
+### Added
+
+- add bounded visitor analysis ([#77](https://github.com/toolCHAINZ/jingle/pull/77))
+
+### Other
+
+- bump pyo3 ([#92](https://github.com/toolCHAINZ/jingle/pull/92))
+
 ## [0.2.3](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.2.2...jingle_sleigh-v0.2.3) - 2025-08-21
 
 ### Other

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `jingle`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `jingle_python`: 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.2.4](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.2.3...jingle_sleigh-v0.2.4) - 2025-09-17

### Added

- add bounded visitor analysis ([#77](https://github.com/toolCHAINZ/jingle/pull/77))

### Other

- bump pyo3 ([#92](https://github.com/toolCHAINZ/jingle/pull/92))
</blockquote>

## `jingle`

<blockquote>

## [0.2.7](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.2.6...jingle-v0.2.7) - 2025-09-17

### Added

- add bounded visitor analysis ([#77](https://github.com/toolCHAINZ/jingle/pull/77))

### Other

- bump pyo3 ([#92](https://github.com/toolCHAINZ/jingle/pull/92))
</blockquote>

## `jingle_python`

<blockquote>

## [0.1.2](https://github.com/toolCHAINZ/jingle/releases/tag/jingle_python-v0.1.1) - 2025-07-10

### Other

- add release-plz ([#61](https://github.com/toolCHAINZ/jingle/pull/61))
- Concretization tweaks ([#56](https://github.com/toolCHAINZ/jingle/pull/56))
- Add forgotten type annotation
- Fix python z3 import error ([#54](https://github.com/toolCHAINZ/jingle/pull/54))
- Fix outdated annotation
- Add Python Type Annotations ([#53](https://github.com/toolCHAINZ/jingle/pull/53))
- Rust Edition 2024 ([#47](https://github.com/toolCHAINZ/jingle/pull/47))
- Python refactor ([#46](https://github.com/toolCHAINZ/jingle/pull/46))
- Add feature flag ([#45](https://github.com/toolCHAINZ/jingle/pull/45))
- Python rlib ([#44](https://github.com/toolCHAINZ/jingle/pull/44))
- Fill out more python APIs ([#43](https://github.com/toolCHAINZ/jingle/pull/43))
- Bump deps ([#42](https://github.com/toolCHAINZ/jingle/pull/42))
- Python Bindings ([#37](https://github.com/toolCHAINZ/jingle/pull/37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).