### PR TITLE
chore: release v0.3.0

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.2.7...jingle-v0.3.0) - 2025-09-19
+
+### Changed
+
+- [**breaking**] Remove unneeded traits and types ([#93](https://github.com/toolCHAINZ/jingle/pull/93))
+
 ## [0.2.7](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.2.6...jingle-v0.2.7) - 2025-09-17
 
 ### Added

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.2.7"
+version = "0.3.0"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"
@@ -19,7 +19,7 @@ name = "jingle"
 required-features = ["bin"]
 
 [dependencies]
-jingle_sleigh = { path = "../jingle_sleigh", version = "0.2.4" }
+jingle_sleigh = { path = "../jingle_sleigh", version = "0.3.0" }
 z3 = { version = "0.18.2" }
 z3-sys = { version = "0.9.9", optional = true }
 thiserror = "2.0"

--- a/jingle_python/Cargo.toml
+++ b/jingle_python/Cargo.toml
@@ -15,4 +15,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 pyo3 = "0.26"
-jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.2.7" }
+jingle = {path = "../jingle", features = ["pyo3", "gimli"], version = "0.3.0" }

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.2.4...jingle_sleigh-v0.3.0) - 2025-09-19
+
+### Changed
+
+- [**breaking**] Remove unneeded traits and types ([#93](https://github.com/toolCHAINZ/jingle/pull/93))
+
+### Other
+
+- add varnode fn ([#96](https://github.com/toolCHAINZ/jingle/pull/96))
+
 ## [0.2.4](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.2.3...jingle_sleigh-v0.2.4) - 2025-09-17
 
 ### Added

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.2.4 -> 0.3.0 (✓ API compatible changes)
* `jingle`: 0.2.7 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.3.0](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.2.4...jingle_sleigh-v0.3.0) - 2025-09-19

### Changed

- [**breaking**] Remove unneeded traits and types ([#93](https://github.com/toolCHAINZ/jingle/pull/93))

### Other

- add varnode fn ([#96](https://github.com/toolCHAINZ/jingle/pull/96))
</blockquote>

## `jingle`

<blockquote>

## [0.3.0](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.2.7...jingle-v0.3.0) - 2025-09-19

### Changed

- [**breaking**] Remove unneeded traits and types ([#93](https://github.com/toolCHAINZ/jingle/pull/93))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).