### PR TITLE
changed: rename PythonResolvedVarNode to ResolvedVarNode

### DIFF
--- a/jingle/src/python/resolved_varnode.rs
+++ b/jingle/src/python/resolved_varnode.rs
@@ -10,7 +10,7 @@ pub enum PythonResolvedVarNodeInner {
     Indirect(JingleDisplay<ResolvedIndirectVarNode>),
 }
 #[derive(Clone)]
-#[pyclass(unsendable, str, name="ResolvedVarNode")]
+#[pyclass(unsendable, str, name = "ResolvedVarNode")]
 pub struct PythonResolvedVarNode {
     pub inner: JingleDisplay<ResolvedVarnode>,
 }


### PR DESCRIPTION
Brings it in line with other python types