### PR TITLE
changed: refactor CPA traits to stop repeating myself

### DIFF
--- a/jingle/src/analysis/bounded_visit/mod.rs
+++ b/jingle/src/analysis/bounded_visit/mod.rs
@@ -5,7 +5,6 @@ use crate::analysis::bounded_visit::state::BoundedStepsState;
 use crate::analysis::cfg::PcodeCfg;
 use crate::analysis::cpa::ConfigurableProgramAnalysis;
 use crate::analysis::cpa::lattice::flat::FlatLattice::Value;
-use crate::analysis::cpa::state::{AbstractState, Successor};
 use crate::analysis::pcode_store::PcodeStore;
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 use jingle_sleigh::PcodeOperation;
@@ -27,16 +26,8 @@ impl<T: PcodeStore> BoundedStepsCpa<T> {
 impl<T: PcodeStore> ConfigurableProgramAnalysis for BoundedStepsCpa<T> {
     type State = BoundedStepsState;
 
-    fn successor_states<'a>(&self, state: &'a Self::State) -> Successor<'a, Self::State> {
-        let opt = state.location.value().cloned();
-        if let Some(addr) = opt {
-            let iter = self.pcode.get_pcode_op_at(addr);
-            iter.into_iter()
-                .flat_map(|op| state.transfer(&op).into_iter())
-                .into()
-        } else {
-            std::iter::empty().into()
-        }
+    fn get_pcode_store(&self) -> &impl PcodeStore {
+        &self.pcode
     }
 
     fn reduce(&mut self, state: &Self::State, dest_state: &Self::State) {

--- a/jingle/src/analysis/bounded_visit/state.rs
+++ b/jingle/src/analysis/bounded_visit/state.rs
@@ -1,6 +1,7 @@
 use crate::analysis::cpa::lattice::JoinSemiLattice;
 use crate::analysis::cpa::lattice::pcode::PcodeAddressLattice;
-use crate::analysis::cpa::state::{AbstractState, MergeOutcome, Successor};
+use crate::analysis::cpa::state::{AbstractState, LocationState, MergeOutcome, Successor};
+use crate::analysis::pcode_store::PcodeStore;
 use jingle_sleigh::PcodeOperation;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
@@ -86,5 +87,11 @@ impl AbstractState for BoundedStepsState {
                 })
                 .into()
         }
+    }
+}
+
+impl LocationState for BoundedStepsState {
+    fn get_operation<T: PcodeStore>(&self, t: &T) -> Option<PcodeOperation> {
+        self.location.get_operation(t)
     }
 }

--- a/jingle/src/analysis/cpa/lattice/pcode.rs
+++ b/jingle/src/analysis/cpa/lattice/pcode.rs
@@ -1,6 +1,7 @@
 use crate::analysis::cpa::lattice::flat::FlatLattice;
 use crate::analysis::cpa::lattice::flat::FlatLattice::Value;
-use crate::analysis::cpa::state::{AbstractState, MergeOutcome, Successor};
+use crate::analysis::cpa::state::{AbstractState, LocationState, MergeOutcome, Successor};
+use crate::analysis::pcode_store::PcodeStore;
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 use jingle_sleigh::PcodeOperation;
 use std::borrow::Borrow;
@@ -22,6 +23,15 @@ impl AbstractState for PcodeAddressLattice {
         match &self {
             PcodeAddressLattice::Value(a) => a.transfer(op).into_iter().map(Value).into(),
             PcodeAddressLattice::Top => once(PcodeAddressLattice::Top).into(),
+        }
+    }
+}
+
+impl LocationState for PcodeAddressLattice {
+    fn get_operation<T: PcodeStore>(&self, t: &T) -> Option<PcodeOperation> {
+        match self {
+            PcodeAddressLattice::Value(a) => t.get_pcode_op_at(a),
+            PcodeAddressLattice::Top => None,
         }
     }
 }

--- a/jingle/src/analysis/cpa/lattice/simple.rs
+++ b/jingle/src/analysis/cpa/lattice/simple.rs
@@ -1,5 +1,6 @@
 use crate::analysis::cpa::lattice::{JoinSemiLattice, PartialJoinSemiLattice};
-use crate::analysis::cpa::state::{AbstractState, MergeOutcome, Successor};
+use crate::analysis::cpa::state::{AbstractState, LocationState, MergeOutcome, Successor};
+use crate::analysis::pcode_store::PcodeStore;
 use jingle_sleigh::PcodeOperation;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
@@ -75,6 +76,15 @@ impl<S: AbstractState + PartialJoinSemiLattice> AbstractState for SimpleLattice<
                 .map(|a| SimpleLattice::Value(a))
                 .into(),
             SimpleLattice::Top => std::iter::empty().into(),
+        }
+    }
+}
+
+impl<S: LocationState + AbstractState + PartialJoinSemiLattice> LocationState for SimpleLattice<S> {
+    fn get_operation<T: PcodeStore>(&self, t: &T) -> Option<PcodeOperation> {
+        match self {
+            SimpleLattice::Value(a) => a.get_operation(t),
+            SimpleLattice::Top => None,
         }
     }
 }

--- a/jingle/src/analysis/cpa/state.rs
+++ b/jingle/src/analysis/cpa/state.rs
@@ -1,4 +1,5 @@
 use crate::analysis::cpa::lattice::JoinSemiLattice;
+use crate::analysis::pcode_store::PcodeStore;
 use jingle_sleigh::PcodeOperation;
 use std::borrow::Borrow;
 
@@ -78,4 +79,8 @@ pub trait AbstractState: JoinSemiLattice + Clone {
     /// (e.g. a resolved indirect jump could return an iterator of locations instead of
     /// having a special "the location is one in this list" variant
     fn transfer<'a, B: Borrow<PcodeOperation>>(&'a self, opcode: B) -> Successor<'a, Self>;
+}
+
+pub trait LocationState: AbstractState {
+    fn get_operation<T: PcodeStore>(&self, t: &T) -> Option<PcodeOperation>;
 }


### PR DESCRIPTION
As a nadded bonus, CPA states need not track location now. This should make it more reasonable for defining composite analyses without tons of cruft