### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.10](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.9...jingle-v0.6.10) - 2026-04-04
+
+### Added
+
+- make varnode Copy and improve Value ergonomics ([#228](https://github.com/toolCHAINZ/jingle/pull/228))
+
+### Other
+
+- Bump z3 and z3-sys versions ([#226](https://github.com/toolCHAINZ/jingle/pull/226))
+
 ## [0.6.9](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.8...jingle-v0.6.9) - 2026-04-01
 
 ### Added

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"
@@ -22,7 +22,7 @@ name = "jingle"
 required-features = ["bin"]
 
 [dependencies]
-jingle_sleigh = { path = "../jingle_sleigh", version = "0.5.3" }
+jingle_sleigh = { path = "../jingle_sleigh", version = "0.5.4" }
 z3 = { version = "0.20.0" }
 z3-sys = { version = "0.11.0", optional = true }
 thiserror = "2.0"

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.3...jingle_sleigh-v0.5.4) - 2026-04-04
+
+### Added
+
+- make varnode Copy and improve Value ergonomics ([#228](https://github.com/toolCHAINZ/jingle/pull/228))
+
 ## [0.5.3](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.2...jingle_sleigh-v0.5.3) - 2026-03-25
 
 ### Added

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `jingle`: 0.6.9 -> 0.6.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.5.4](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.3...jingle_sleigh-v0.5.4) - 2026-04-04

### Added

- make varnode Copy and improve Value ergonomics ([#228](https://github.com/toolCHAINZ/jingle/pull/228))
</blockquote>

## `jingle`

<blockquote>

## [0.6.10](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.9...jingle-v0.6.10) - 2026-04-04

### Added

- make varnode Copy and improve Value ergonomics ([#228](https://github.com/toolCHAINZ/jingle/pull/228))

### Other

- Bump z3 and z3-sys versions ([#226](https://github.com/toolCHAINZ/jingle/pull/226))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).