### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.13](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.12...jingle-v0.6.13) - 2026-04-13
+
+### Other
+
+- jingle should only target minor version ([#235](https://github.com/toolCHAINZ/jingle/pull/235))
+
 ## [0.6.12](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.11...jingle-v0.6.12) - 2026-04-10
 
 ### Added

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.5...jingle_sleigh-v0.5.6) - 2026-04-13
+
+### Fixed
+
+- filter non-load ELF sections from gimli ([#233](https://github.com/toolCHAINZ/jingle/pull/233))
+
 ## [0.5.5](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.4...jingle_sleigh-v0.5.5) - 2026-04-10
 
 ### Added

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.5.5 -> 0.5.6 (✓ API compatible changes)
* `jingle`: 0.6.12 -> 0.6.13 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.5.6](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.5...jingle_sleigh-v0.5.6) - 2026-04-13

### Fixed

- filter non-load ELF sections from gimli ([#233](https://github.com/toolCHAINZ/jingle/pull/233))
</blockquote>

## `jingle`

<blockquote>

## [0.6.13](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.12...jingle-v0.6.13) - 2026-04-13

### Other

- jingle should only target minor version ([#235](https://github.com/toolCHAINZ/jingle/pull/235))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).