### PR TITLE
feat: or expressions

### DIFF
--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -21,8 +21,8 @@ use internment::Intern;
 /// How to merge conflicting valuations for a single varnode when joining states.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum MergeBehavior {
-    /// Combine differing valuations into an `Or(...)` expression (higher precision).
-    Or,
+    /// Combine differing valuations into a `Choice(...)` expression (higher precision).
+    Choice,
     /// Converge differing valuations to `Top` (lower precision).
     Top,
 }
@@ -66,7 +66,7 @@ impl ValuationState {
         Self {
             valuation: ValuationSet::new(),
             arch_info,
-            merge_behavior: MergeBehavior::Or,
+            merge_behavior: MergeBehavior::Choice,
         }
     }
 
@@ -153,18 +153,15 @@ impl ValuationState {
                 }
             }
 
-            // This uses the wrong "Or". When we re-add bitor, use that
-            //
-            // PcodeOperation::IntOr { input0, input1, .. }
-            // | PcodeOperation::BoolOr { input0, input1, .. } => {
-            //     let a = Value::from_varnode_or_entry(self, input0);
-            //     let b = Value::from_varnode_or_entry(self, input1);
-            //     if let Some(GeneralizedVarNode::Direct(output_vn)) = op.output() {
-            //         new_state
-            //             .valuation
-            //             .add(output_vn, Value::or(a, b).simplify());
-            //     }
-            // }
+            PcodeOperation::IntOr { input0, input1, .. }
+            | PcodeOperation::BoolOr { input0, input1, .. } => {
+                let a = Value::from_varnode_or_entry(self, input0);
+                let b = Value::from_varnode_or_entry(self, input1);
+                if let Some(GeneralizedVarNode::Direct(output_vn)) = op.output() {
+                    new_state.valuation.add(output_vn, (a | b).simplify());
+                }
+            }
+
             PcodeOperation::IntAnd { input0, input1, .. }
             | PcodeOperation::BoolAnd { input0, input1, .. } => {
                 let a = Value::from_varnode_or_entry(self, input0);
@@ -174,7 +171,6 @@ impl ValuationState {
                 }
             }
 
-            // Shift operations
             PcodeOperation::IntLeftShift { input0, input1, .. } => {
                 let a = Value::from_varnode_or_entry(self, input0);
                 let b = Value::from_varnode_or_entry(self, input1);
@@ -498,8 +494,8 @@ impl JoinSemiLattice for ValuationState {
                         *my_val = Value::Top;
                     } else if my_val != other_val {
                         match self.merge_behavior {
-                            MergeBehavior::Or => {
-                                let combined = Value::or(my_val.clone(), other_val.clone());
+                            MergeBehavior::Choice => {
+                                let combined = Value::choice(my_val.clone(), other_val.clone());
                                 *my_val = combined.simplify();
                             }
                             MergeBehavior::Top => {
@@ -510,10 +506,10 @@ impl JoinSemiLattice for ValuationState {
                 }
                 None => {
                     match self.merge_behavior {
-                        MergeBehavior::Or => {
+                        MergeBehavior::Choice => {
                             let entry = Value::from_varnode_or_entry(self, key);
-                            let or = Value::or(entry, other_val.clone());
-                            self.valuation.add(*key, or.simplify());
+                            let choice = Value::choice(entry, other_val.clone());
+                            self.valuation.add(*key, choice.simplify());
                         }
                         MergeBehavior::Top => {
                             // If the other state has a direct write that we don't, we have to assume it could be anything.
@@ -533,8 +529,8 @@ impl JoinSemiLattice for ValuationState {
                         *my_val = Value::Top;
                     } else if my_val != other_val {
                         match self.merge_behavior {
-                            MergeBehavior::Or => {
-                                let combined = Value::or(my_val.clone(), other_val.clone());
+                            MergeBehavior::Choice => {
+                                let combined = Value::choice(my_val.clone(), other_val.clone());
                                 *my_val = combined.simplify();
                             }
                             MergeBehavior::Top => {

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -146,13 +146,17 @@ pub struct AddExpr(pub Intern<Value>, pub Intern<Value>, pub usize);
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct SubExpr(pub Intern<Value>, pub Intern<Value>, pub usize);
 
-/// An expression representing two possible values
+/// An expression representing two possible values (abstract interpretation choice)
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
-pub struct Or(pub Intern<Value>, pub Intern<Value>, pub usize);
+pub struct Choice(pub Intern<Value>, pub Intern<Value>, pub usize);
 
 /// A bitwise XOR expression
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct XorExpr(pub Intern<Value>, pub Intern<Value>, pub usize);
+
+/// A bitwise OR expression
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct OrExpr(pub Intern<Value>, pub Intern<Value>, pub usize);
 
 /// A bitwise AND expression
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
@@ -258,8 +262,9 @@ pub enum Value {
     Add(AddExpr),
     Sub(SubExpr),
 
-    Or(Or),
+    Choice(Choice),
     Xor(XorExpr),
+    Or(OrExpr),
     And(AndExpr),
     IntLeftShift(IntLeftShiftExpr),
     IntRightShift(IntRightShiftExpr),
@@ -325,8 +330,9 @@ impl Value {
             Value::Mul(_)
                 | Value::Add(_)
                 | Value::Sub(_)
-                | Value::Or(_)
+                | Value::Choice(_)
                 | Value::Xor(_)
+                | Value::Or(_)
                 | Value::And(_)
                 | Value::IntLeftShift(_)
                 | Value::IntRightShift(_)
@@ -372,10 +378,10 @@ impl Value {
         }
     }
 
-    /// Accessor for `Or` variant.
-    pub fn as_or(&self) -> Option<&Or> {
+    /// Accessor for `Choice` variant.
+    pub fn as_choice(&self) -> Option<&Choice> {
         match self {
-            Value::Or(o) => Some(o),
+            Value::Choice(o) => Some(o),
             _ => None,
         }
     }
@@ -384,6 +390,14 @@ impl Value {
     pub fn as_xor(&self) -> Option<&XorExpr> {
         match self {
             Value::Xor(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    /// Accessor for `Or` variant (bitwise OR).
+    pub fn as_or(&self) -> Option<&OrExpr> {
+        match self {
+            Value::Or(o) => Some(o),
             _ => None,
         }
     }
@@ -503,8 +517,9 @@ impl Value {
             Value::Mul(MulExpr(_, _, s))
             | Value::Add(AddExpr(_, _, s))
             | Value::Sub(SubExpr(_, _, s))
-            | Value::Or(Or(_, _, s))
+            | Value::Choice(Choice(_, _, s))
             | Value::Xor(XorExpr(_, _, s))
+            | Value::Or(OrExpr(_, _, s))
             | Value::And(AndExpr(_, _, s))
             | Value::IntLeftShift(IntLeftShiftExpr(_, _, s))
             | Value::IntRightShift(IntRightShiftExpr(_, _, s))
@@ -553,12 +568,13 @@ impl Value {
         Value::Const(Const(vn))
     }
 
-    /// Construct an `Or(...)` node from two children. Size is derived from children.
-    pub fn or(left: impl IntoInternedValue, right: impl IntoInternedValue) -> Self {
+    /// Construct a `Choice(...)` node from two children. Size is derived from children.
+    /// This represents an abstract interpretation choice between two possible values.
+    pub fn choice(left: impl IntoInternedValue, right: impl IntoInternedValue) -> Self {
         let left = left.into_interned();
         let right = right.into_interned();
         let s = std::cmp::max(left.size(), right.size());
-        Value::Or(Or(left, right, s))
+        Value::Choice(Choice(left, right, s))
     }
 
     /// Construct a `Xor(...)` node from two children. Size is derived from children.
@@ -567,6 +583,14 @@ impl Value {
         let right = right.into_interned();
         let s = std::cmp::max(left.size(), right.size());
         Value::Xor(XorExpr(left, right, s))
+    }
+
+    /// Construct an `Or(...)` node from two children (bitwise OR). Size is derived from children.
+    pub fn or(left: impl IntoInternedValue, right: impl IntoInternedValue) -> Self {
+        let left = left.into_interned();
+        let right = right.into_interned();
+        let s = std::cmp::max(left.size(), right.size());
+        Value::Or(OrExpr(left, right, s))
     }
 
     /// Construct an `And(...)` node from two children. Size is derived from children.
@@ -691,15 +715,15 @@ impl Value {
         }
     }
 
-    /// Normalize Or operands so that the canonical form has a non-Or on the left
-    /// and an Or on the right when one operand is an Or. This makes simplifications
-    /// like `Or(Or(a,b), c)` and `Or(c, Or(a,b))` handled uniformly.
-    fn normalize_or(left: Value, right: Value) -> (Value, Value) {
-        let left_is_or = matches!(left, Value::Or(_));
-        let right_is_or = matches!(right, Value::Or(_));
+    /// Normalize Choice operands so that the canonical form has a non-Choice on the left
+    /// and a Choice on the right when one operand is a Choice. This makes simplifications
+    /// like `Choice(Choice(a,b), c)` and `Choice(c, Choice(a,b))` handled uniformly.
+    fn normalize_choice(left: Value, right: Value) -> (Value, Value) {
+        let left_is_choice = matches!(left, Value::Choice(_));
+        let right_is_choice = matches!(right, Value::Choice(_));
 
-        // If left is an Or and right is not, swap so the Or is on the right.
-        if left_is_or && !right_is_or {
+        // If left is a Choice and right is not, swap so the Choice is on the right.
+        if left_is_choice && !right_is_choice {
             (right, left)
         } else {
             (left, right)
@@ -716,28 +740,29 @@ impl Value {
             Value::Mul(_) => 3,
             Value::Add(_) => 4,
             Value::Sub(_) => 5,
-            Value::Or(_) => 6,
+            Value::Choice(_) => 6,
             Value::Xor(_) => 7,
-            Value::And(_) => 8,
-            Value::IntLeftShift(_) => 9,
-            Value::IntRightShift(_) => 10,
-            Value::IntSignedRightShift(_) => 11,
-            Value::Load(_) => 12,
-            Value::ZeroExtend(_) => 13,
-            Value::SignExtend(_) => 14,
-            Value::Extract(_) => 15,
-            Value::Top => 16,
-            Value::IntSLess(_) => 17,
-            Value::IntEqual(_) => 18,
-            Value::IntLess(_) => 19,
-            Value::PopCount(_) => 20,
-            Value::Int2Comp(_) => 21,
-            Value::IntNotEqual(_) => 22,
-            Value::IntLessEqual(_) => 23,
-            Value::IntSLessEqual(_) => 24,
-            Value::IntCarry(_) => 25,
-            Value::IntSCarry(_) => 26,
-            Value::IntSBorrow(_) => 27,
+            Value::Or(_) => 8,
+            Value::And(_) => 9,
+            Value::IntLeftShift(_) => 10,
+            Value::IntRightShift(_) => 11,
+            Value::IntSignedRightShift(_) => 12,
+            Value::Load(_) => 13,
+            Value::ZeroExtend(_) => 14,
+            Value::SignExtend(_) => 15,
+            Value::Extract(_) => 16,
+            Value::Top => 17,
+            Value::IntSLess(_) => 18,
+            Value::IntEqual(_) => 19,
+            Value::IntLess(_) => 20,
+            Value::PopCount(_) => 21,
+            Value::Int2Comp(_) => 22,
+            Value::IntNotEqual(_) => 23,
+            Value::IntLessEqual(_) => 24,
+            Value::IntSLessEqual(_) => 25,
+            Value::IntCarry(_) => 26,
+            Value::IntSCarry(_) => 27,
+            Value::IntSBorrow(_) => 28,
         }
     }
 }
@@ -748,8 +773,9 @@ impl Simplify for Value {
             Value::Mul(expr) => expr.simplify(),
             Value::Add(expr) => expr.simplify(),
             Value::Sub(expr) => expr.simplify(),
-            Value::Or(expr) => expr.simplify(),
+            Value::Choice(expr) => expr.simplify(),
             Value::Xor(expr) => expr.simplify(),
+            Value::Or(expr) => expr.simplify(),
             Value::And(expr) => expr.simplify(),
             Value::IntLeftShift(expr) => expr.simplify(),
             Value::IntRightShift(expr) => expr.simplify(),
@@ -807,6 +833,15 @@ impl BitAnd for Value {
     fn bitand(self, rhs: Self) -> Self::Output {
         let s = std::cmp::max(self.size(), rhs.size());
         Value::And(AndExpr(Intern::new(self), Intern::new(rhs), s))
+    }
+}
+
+impl std::ops::BitOr for Value {
+    type Output = Value;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        let s = std::cmp::max(self.size(), rhs.size());
+        Value::Or(OrExpr(Intern::new(self), Intern::new(rhs), s))
     }
 }
 
@@ -1033,7 +1068,7 @@ impl Simplify for MulExpr {
     }
 }
 
-impl Simplify for Or {
+impl Simplify for Choice {
     fn simplify(&self) -> Value {
         let a_intern = self.0;
         let b_intern = self.1;
@@ -1047,13 +1082,13 @@ impl Simplify for Or {
             return Value::Top;
         }
 
-        // normalize so that if one side is an Or and the other is not, the Or is on the right
-        // (canonical shape: non-Or on left, Or on right)
-        let (mut left, mut right) = Value::normalize_or(a_s, b_s);
+        // normalize so that if one side is a Choice and the other is not, the Choice is on the right
+        // (canonical shape: non-Choice on left, Choice on right)
+        let (mut left, mut right) = Value::normalize_choice(a_s, b_s);
 
-        // If both sides are non-Or, enforce deterministic ordering by variant rank.
-        if !matches!(left, Value::Or(_))
-            && !matches!(right, Value::Or(_))
+        // If both sides are non-Choice, enforce deterministic ordering by variant rank.
+        if !matches!(left, Value::Choice(_))
+            && !matches!(right, Value::Choice(_))
             && Value::variant_rank(&left) > Value::variant_rank(&right)
         {
             std::mem::swap(&mut left, &mut right);
@@ -1064,67 +1099,71 @@ impl Simplify for Or {
             return left;
         }
 
-        // Collapse nested duplicates: Or(a, Or(a, b)) -> Or(a, b)
-        if let Value::Or(Or(inner_a, inner_b, _)) = &right {
+        // Collapse nested duplicates: Choice(a, Choice(a, b)) -> Choice(a, b)
+        if let Value::Choice(Choice(inner_a, inner_b, _)) = &right {
             if inner_a.as_ref() == &left {
-                let inner = Value::Or(Or(Intern::new(left), *inner_b, right.size())).simplify();
+                let inner =
+                    Value::Choice(Choice(Intern::new(left), *inner_b, right.size())).simplify();
                 return inner;
             }
             if inner_b.as_ref() == &left {
-                let inner = Value::Or(Or(Intern::new(left), *inner_a, right.size())).simplify();
+                let inner =
+                    Value::Choice(Choice(Intern::new(left), *inner_a, right.size())).simplify();
                 return inner;
             }
         }
 
-        // Factor common child between two Ors:
-        // Or(Or(a,b), Or(a,c)) -> Or(a, Or(b,c)) and symmetric variants.
-        if let (Value::Or(Or(l1, l2, _)), Value::Or(Or(r1, r2, _))) = (&left, &right) {
+        // Factor common child between two Choices:
+        // Choice(Choice(a,b), Choice(a,c)) -> Choice(a, Choice(b,c)) and symmetric variants.
+        if let (Value::Choice(Choice(l1, l2, _)), Value::Choice(Choice(r1, r2, _))) =
+            (&left, &right)
+        {
             // check all combinations for equal common child
             if l1.as_ref() == r1.as_ref() {
-                let inner = Value::Or(Or(
+                let inner = Value::Choice(Choice(
                     *l2,
                     *r2,
                     std::cmp::max(l2.as_ref().size(), r2.as_ref().size()),
                 ))
                 .simplify();
                 let s = std::cmp::max(l1.as_ref().size(), inner.size());
-                return Value::Or(Or(*l1, Intern::new(inner), s)).simplify();
+                return Value::Choice(Choice(*l1, Intern::new(inner), s)).simplify();
             }
             if l1.as_ref() == r2.as_ref() {
-                let inner = Value::Or(Or(
+                let inner = Value::Choice(Choice(
                     *l2,
                     *r1,
                     std::cmp::max(l2.as_ref().size(), r1.as_ref().size()),
                 ))
                 .simplify();
                 let s = std::cmp::max(l1.as_ref().size(), inner.size());
-                return Value::Or(Or(*l1, Intern::new(inner), s)).simplify();
+                return Value::Choice(Choice(*l1, Intern::new(inner), s)).simplify();
             }
             if l2.as_ref() == r1.as_ref() {
-                let inner = Value::Or(Or(
+                let inner = Value::Choice(Choice(
                     *l1,
                     *r2,
                     std::cmp::max(l1.as_ref().size(), r2.as_ref().size()),
                 ))
                 .simplify();
                 let s = std::cmp::max(l2.as_ref().size(), inner.size());
-                return Value::Or(Or(*l2, Intern::new(inner), s)).simplify();
+                return Value::Choice(Choice(*l2, Intern::new(inner), s)).simplify();
             }
             if l2.as_ref() == r2.as_ref() {
-                let inner = Value::Or(Or(
+                let inner = Value::Choice(Choice(
                     *l1,
                     *r1,
                     std::cmp::max(l1.as_ref().size(), r1.as_ref().size()),
                 ))
                 .simplify();
                 let s = std::cmp::max(l2.as_ref().size(), inner.size());
-                return Value::Or(Or(*l2, Intern::new(inner), s)).simplify();
+                return Value::Choice(Choice(*l2, Intern::new(inner), s)).simplify();
             }
         }
 
         // default: rebuild with simplified children
         let s = std::cmp::max(left.size(), right.size());
-        Value::Or(Or(Intern::new(left), Intern::new(right), s))
+        Value::Choice(Choice(Intern::new(left), Intern::new(right), s))
     }
 }
 
@@ -1216,6 +1255,54 @@ impl Simplify for AndExpr {
 
         let s = std::cmp::max(left.size(), right.size());
         Value::And(AndExpr(Intern::new(left), Intern::new(right), s))
+    }
+}
+
+impl Simplify for OrExpr {
+    fn simplify(&self) -> Value {
+        let a_s = self.0.as_ref().simplify();
+        let b_s = self.1.as_ref().simplify();
+
+        if matches!(a_s, Value::Top) || matches!(b_s, Value::Top) {
+            return Value::Top;
+        }
+
+        let (left, right) = Value::normalize_commutative(a_s, b_s);
+
+        // both const -> fold
+        if let (Some(left_vn), Some(right_vn)) = (left.as_const(), right.as_const()) {
+            let res = (left_vn.offset() | right_vn.offset()) as i64;
+            let size = Value::derive_size_from(&left).max(Value::derive_size_from(&right));
+            return Value::make_const(res, size as u32);
+        }
+
+        // x | x -> x
+        if left == right {
+            return left;
+        }
+
+        // x | 0 -> x
+        if right.as_const().map(|vn| vn.offset()) == Some(0) {
+            return left;
+        }
+
+        // x | all-ones -> all-ones
+        let all_ones = match left.size() {
+            1 => Some(0xFF_u64),
+            2 => Some(0xFFFF_u64),
+            4 => Some(0xFFFF_FFFF_u64),
+            8 => Some(u64::MAX),
+            _ => None,
+        };
+        if let Some(mask) = all_ones {
+            if right.as_const().map(|vn| vn.offset()) == Some(mask) {
+                let size = Value::derive_size_from(&left);
+                return Value::make_const(mask as i64, size as u32);
+            }
+        }
+
+        let s = std::cmp::max(left.size(), right.size());
+        Value::Or(OrExpr(Intern::new(left), Intern::new(right), s))
     }
 }
 
@@ -1780,7 +1867,7 @@ impl JingleDisplay for Value {
                 write!(f, "-")?;
                 fmt_operand_jingle(f, b.as_ref(), info)
             }
-            Value::Or(Or(a, b, _)) => {
+            Value::Choice(Choice(a, b, _)) => {
                 fmt_operand_jingle(f, a.as_ref(), info)?;
                 write!(f, "||")?;
                 fmt_operand_jingle(f, b.as_ref(), info)
@@ -1788,6 +1875,11 @@ impl JingleDisplay for Value {
             Value::Xor(XorExpr(a, b, _)) => {
                 fmt_operand_jingle(f, a.as_ref(), info)?;
                 write!(f, "^")?;
+                fmt_operand_jingle(f, b.as_ref(), info)
+            }
+            Value::Or(OrExpr(a, b, _)) => {
+                fmt_operand_jingle(f, a.as_ref(), info)?;
+                write!(f, "|")?;
                 fmt_operand_jingle(f, b.as_ref(), info)
             }
             Value::And(AndExpr(a, b, _)) => {
@@ -1921,7 +2013,7 @@ impl std::fmt::Display for Value {
                 write!(f, "-")?;
                 fmt_operand(f, b.as_ref())
             }
-            Value::Or(Or(a, b, _)) => {
+            Value::Choice(Choice(a, b, _)) => {
                 fmt_operand(f, a.as_ref())?;
                 write!(f, "||")?;
                 fmt_operand(f, b.as_ref())
@@ -1929,6 +2021,11 @@ impl std::fmt::Display for Value {
             Value::Xor(XorExpr(a, b, _)) => {
                 fmt_operand(f, a.as_ref())?;
                 write!(f, "^")?;
+                fmt_operand(f, b.as_ref())
+            }
+            Value::Or(OrExpr(a, b, _)) => {
+                fmt_operand(f, a.as_ref())?;
+                write!(f, "|")?;
                 fmt_operand(f, b.as_ref())
             }
             Value::And(AndExpr(a, b, _)) => {
@@ -2042,7 +2139,7 @@ impl std::fmt::LowerHex for Value {
                 write!(f, "-")?;
                 fmt_operand_hex(f, b.as_ref())
             }
-            Value::Or(Or(a, b, _)) => {
+            Value::Choice(Choice(a, b, _)) => {
                 fmt_operand_hex(f, a.as_ref())?;
                 write!(f, "||")?;
                 fmt_operand_hex(f, b.as_ref())
@@ -2050,6 +2147,11 @@ impl std::fmt::LowerHex for Value {
             Value::Xor(XorExpr(a, b, _)) => {
                 fmt_operand_hex(f, a.as_ref())?;
                 write!(f, "^")?;
+                fmt_operand_hex(f, b.as_ref())
+            }
+            Value::Or(OrExpr(a, b, _)) => {
+                fmt_operand_hex(f, a.as_ref())?;
+                write!(f, "|")?;
                 fmt_operand_hex(f, b.as_ref())
             }
             Value::And(AndExpr(a, b, _)) => {

--- a/jingle/src/analysis/valuation/simple/value_tests.rs
+++ b/jingle/src/analysis/valuation/simple/value_tests.rs
@@ -222,94 +222,94 @@ fn mul_wrapping() {
     assert_eq!(result, Value::make_const(i64::MAX.wrapping_mul(2), 8));
 }
 
-// --- Or ----------------------------------------------------------------------
+// --- Choice (abstract interpretation) ----------------------------------------
 
 #[test]
 fn or_identical_children() {
     let a = Value::entry(vn_a());
-    let result = Value::or(a.clone(), a).simplify();
+    let result = Value::choice(a.clone(), a).simplify();
     assert_eq!(result, Value::entry(vn_a()));
 }
 
 #[test]
 fn or_top_left() {
     let a = Value::entry(vn_a());
-    let result = Value::or(Value::Top, a).simplify();
+    let result = Value::choice(Value::Top, a).simplify();
     assert_eq!(result, Value::Top);
 }
 
 #[test]
 fn or_top_right() {
     let a = Value::entry(vn_a());
-    let result = Value::or(a, Value::Top).simplify();
+    let result = Value::choice(a, Value::Top).simplify();
     assert_eq!(result, Value::Top);
 }
 
 #[test]
 fn or_nested_duplicate_inner_left() {
-    // Or(a, Or(a, b))  =>  Or(a, b)
+    // Choice(a, Choice(a, b))  =>  Choice(a, b)
     let a = Value::entry(vn_a());
     let b = Value::entry(vn_b());
-    let inner = Value::or(a.clone(), b.clone());
-    let result = Value::or(a.clone(), inner).simplify();
-    let or = result.as_or().expect("expected Or");
-    assert_eq!(or.0.as_ref(), &a);
-    assert_eq!(or.1.as_ref(), &b);
+    let inner = Value::choice(a.clone(), b.clone());
+    let result = Value::choice(a.clone(), inner).simplify();
+    let choice = result.as_choice().expect("expected Choice");
+    assert_eq!(choice.0.as_ref(), &a);
+    assert_eq!(choice.1.as_ref(), &b);
 }
 
 #[test]
 fn or_nested_duplicate_inner_right() {
-    // Or(a, Or(b, a))  =>  Or(a, b)
+    // Choice(a, Choice(b, a))  =>  Choice(a, b)
     let a = Value::entry(vn_a());
     let b = Value::entry(vn_b());
-    let inner = Value::or(b.clone(), a.clone());
-    let result = Value::or(a.clone(), inner).simplify();
-    let or = result.as_or().expect("expected Or");
-    assert_eq!(or.0.as_ref(), &a);
-    assert_eq!(or.1.as_ref(), &b);
+    let inner = Value::choice(b.clone(), a.clone());
+    let result = Value::choice(a.clone(), inner).simplify();
+    let choice = result.as_choice().expect("expected Choice");
+    assert_eq!(choice.0.as_ref(), &a);
+    assert_eq!(choice.1.as_ref(), &b);
 }
 
 #[test]
 fn or_common_factor_l1_r1() {
-    // Or(Or(a,b), Or(a,c))  =>  Or(a, Or(b,c))
+    // Choice(Choice(a,b), Choice(a,c))  =>  Choice(a, Choice(b,c))
     let a = Value::entry(vn_a());
     let b = Value::entry(vn_b());
     let c = Value::entry(vn_c());
-    let left = Value::or(a.clone(), b.clone());
-    let right = Value::or(a.clone(), c.clone());
-    let result = Value::or(left, right).simplify();
-    let outer = result.as_or().expect("expected outer Or");
+    let left = Value::choice(a.clone(), b.clone());
+    let right = Value::choice(a.clone(), c.clone());
+    let result = Value::choice(left, right).simplify();
+    let outer = result.as_choice().expect("expected outer Choice");
     assert_eq!(outer.0.as_ref(), &a, "common factor should be left child");
-    let inner = outer.1.as_ref().as_or().expect("expected inner Or");
+    let inner = outer.1.as_ref().as_choice().expect("expected inner Choice");
     let inner_vals: Vec<_> = vec![inner.0.as_ref().clone(), inner.1.as_ref().clone()];
-    assert!(inner_vals.contains(&b), "inner Or should contain b");
-    assert!(inner_vals.contains(&c), "inner Or should contain c");
+    assert!(inner_vals.contains(&b), "inner Choice should contain b");
+    assert!(inner_vals.contains(&c), "inner Choice should contain c");
 }
 
 #[test]
 fn or_canonical_or_on_right() {
-    // Or(Or(a,b), c)  =>  non-Or on left, Or on right
+    // Choice(Choice(a,b), c)  =>  non-Choice on left, Choice on right
     let a = Value::entry(vn_a());
     let b = Value::entry(vn_b());
     let c = Value::const_(42);
-    let inner = Value::or(a, b);
-    let result = Value::or(inner, c).simplify();
-    let or = result.as_or().expect("expected Or");
-    assert!(or.0.as_or().is_none(), "left child should not be an Or");
-    assert!(or.1.as_or().is_some(), "right child should be an Or");
+    let inner = Value::choice(a, b);
+    let result = Value::choice(inner, c).simplify();
+    let choice = result.as_choice().expect("expected Choice");
+    assert!(choice.0.as_choice().is_none(), "left child should not be a Choice");
+    assert!(choice.1.as_choice().is_some(), "right child should be a Choice");
 }
 
 #[test]
 fn or_variant_ordering() {
-    // Or(entry, const)  =>  canonical form: const (rank 0) on left, entry (rank 1) on right
-    let result = Value::or(Value::entry(vn_b()), Value::const_(7)).simplify();
-    let or = result.as_or().expect("expected Or");
+    // Choice(entry, const)  =>  canonical form: const (rank 0) on left, entry (rank 1) on right
+    let result = Value::choice(Value::entry(vn_b()), Value::const_(7)).simplify();
+    let choice = result.as_choice().expect("expected Choice");
     assert!(
-        or.0.as_const().is_some(),
+        choice.0.as_const().is_some(),
         "lower-rank const should be on left"
     );
     assert!(
-        or.1.as_entry().is_some(),
+        choice.1.as_entry().is_some(),
         "higher-rank entry should be on right"
     );
 }
@@ -401,6 +401,55 @@ fn and_normalizes_const_to_right() {
     let and = result.as_and().expect("expected And node");
     assert!(and.0.as_entry().is_some(), "expected entry on left");
     assert!(and.1.as_const().is_some(), "expected const on right");
+}
+
+// --- OrExpr (bitwise OR) -----------------------------------------------------
+
+#[test]
+fn or_bitwise_const_folding() {
+    let result = (Value::const_(0b1010) | Value::const_(0b1100)).simplify();
+    assert_eq!(result, Value::make_const(0b1110, 8));
+}
+
+#[test]
+fn or_bitwise_self() {
+    let result = (Value::entry(vn_a()) | Value::entry(vn_a())).simplify();
+    assert_eq!(result, Value::entry(vn_a()));
+}
+
+#[test]
+fn or_bitwise_identity_zero() {
+    let result = (Value::entry(vn_a()) | Value::const_(0)).simplify();
+    assert_eq!(result, Value::entry(vn_a()));
+}
+
+#[test]
+fn or_bitwise_all_ones() {
+    // entry | 0xFF -> 0xFF (for 1-byte values)
+    let vn = VarNode::new(0x100u64, 1u32, 0u32);
+    let entry = Value::entry(vn);
+    let result = (entry | Value::make_const(0xFF_i64, 1)).simplify();
+    assert_eq!(result, Value::make_const(0xFF, 1));
+}
+
+#[test]
+fn or_bitwise_top_propagation() {
+    let result = (Value::Top | Value::entry(vn_a())).simplify();
+    assert_eq!(result, Value::Top);
+}
+
+#[test]
+fn or_bitwise_symbolic_stays_symbolic() {
+    let result = (Value::entry(vn_a()) | Value::entry(vn_b())).simplify();
+    assert!(result.as_or().is_some(), "expected Or node");
+}
+
+#[test]
+fn or_bitwise_normalizes_const_to_right() {
+    let result = (Value::const_(5) | Value::entry(vn_a())).simplify();
+    let or = result.as_or().expect("expected Or node");
+    assert!(or.0.as_entry().is_some(), "expected entry on left");
+    assert!(or.1.as_const().is_some(), "expected const on right");
 }
 
 // --- Load --------------------------------------------------------------------

--- a/jingle/src/analysis/valuation/simple/value_tests.rs
+++ b/jingle/src/analysis/valuation/simple/value_tests.rs
@@ -295,8 +295,14 @@ fn or_canonical_or_on_right() {
     let inner = Value::choice(a, b);
     let result = Value::choice(inner, c).simplify();
     let choice = result.as_choice().expect("expected Choice");
-    assert!(choice.0.as_choice().is_none(), "left child should not be a Choice");
-    assert!(choice.1.as_choice().is_some(), "right child should be a Choice");
+    assert!(
+        choice.0.as_choice().is_none(),
+        "left child should not be a Choice"
+    );
+    assert!(
+        choice.1.as_choice().is_some(),
+        "right child should be a Choice"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Forgot to define Or expressions. Renamed the old "Or", which was an analysis-level Or node (e.g. one path has value a and one path as value b). This one is now a proper bitor.

The old "or" has been renamed to the less confusing "choice".