### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.19](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.18...jingle-v0.6.19) - 2026-04-30
+
+### Added
+
+- remove Clone bound on JingleDisplay ([#256](https://github.com/toolCHAINZ/jingle/pull/256))
+
 ## [0.6.18](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.17...jingle-v0.6.18) - 2026-04-29
 
 ### Added

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.7...jingle_sleigh-v0.5.8) - 2026-04-30
+
+### Added
+
+- remove Clone bound on JingleDisplay ([#256](https://github.com/toolCHAINZ/jingle/pull/256))
+
 ## [0.5.7](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.6...jingle_sleigh-v0.5.7) - 2026-04-16
 
 ### Added

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.5.7 -> 0.5.8 (✓ API compatible changes)
* `jingle`: 0.6.18 -> 0.6.19 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.5.8](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.7...jingle_sleigh-v0.5.8) - 2026-04-30

### Added

- remove Clone bound on JingleDisplay ([#256](https://github.com/toolCHAINZ/jingle/pull/256))
</blockquote>

## `jingle`

<blockquote>

## [0.6.19](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.18...jingle-v0.6.19) - 2026-04-30

### Added

- remove Clone bound on JingleDisplay ([#256](https://github.com/toolCHAINZ/jingle/pull/256))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).