### PR TITLE
feat: add "bind" value

### DIFF
--- a/jingle/src/analysis/valuation/simple/valuation.rs
+++ b/jingle/src/analysis/valuation/simple/valuation.rs
@@ -210,6 +210,21 @@ impl Location {
     pub fn is_indirect(&self) -> bool {
         matches!(self, Self::Indirect(_))
     }
+
+    pub fn size(&self) -> Option<usize> {
+        match self {
+            Self::Direct(vn) => Some(vn.size()),
+            Self::Indirect(Value::Load(load)) => Some(load.1),
+            _ => None,
+        }
+    }
+
+    pub fn as_value(&self) -> Value {
+        match self {
+            Self::Indirect(v) => v.clone(),
+            Self::Direct(v) => Value::entry(v.clone()),
+        }
+    }
 }
 
 // Allow converting a raw `VarNode` directly into a `Location::Direct`.

--- a/jingle/src/analysis/valuation/simple/valuation.rs
+++ b/jingle/src/analysis/valuation/simple/valuation.rs
@@ -222,7 +222,7 @@ impl Location {
     pub fn as_value(&self) -> Value {
         match self {
             Self::Indirect(v) => v.clone(),
-            Self::Direct(v) => Value::entry(v.clone()),
+            Self::Direct(v) => Value::entry(*v),
         }
     }
 }

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -973,11 +973,9 @@ impl Simplify for Value {
             Value::IntCarry(expr) => expr.simplify(),
             Value::IntSCarry(expr) => expr.simplify(),
             Value::IntSBorrow(expr) => expr.simplify(),
-            Value::Entry(_)
-            | Value::Offset(_)
-            | Value::Const(_)
-            | Value::Bind(_)
-            | Value::Top => self.clone(),
+            Value::Entry(_) | Value::Offset(_) | Value::Const(_) | Value::Bind(_) | Value::Top => {
+                self.clone()
+            }
         }
     }
 }

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -16,7 +16,7 @@ use std::{
 
 /// Global atomic counter used exclusively by [`Value::fresh_unique`] to mint
 /// monotonically-increasing, globally-unique identifiers.
-static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static BIND_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 mod sealed {
     pub trait Sealed {}
@@ -261,9 +261,9 @@ pub struct Extract(pub Intern<Value>, pub usize, pub usize);
 /// is via [`Value::fresh_unique`], which draws a monotonically-increasing id
 /// from a shared atomic counter.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
-pub struct Unique(u64, usize);
+pub struct Bind(u64, usize);
 
-impl Unique {
+impl Bind {
     /// The globally-unique numeric identifier for this value.
     pub fn id(&self) -> u64 {
         self.0
@@ -335,7 +335,7 @@ pub enum Value {
 
     /// A globally-unique opaque value. Construct exclusively via
     /// [`Value::fresh_unique`]; cloning an existing `Unique` preserves the id.
-    Unique(Unique),
+    Bind(Bind),
 
     Top,
 }
@@ -388,9 +388,9 @@ impl Value {
     }
 
     /// Accessor for the `Unique` variant.
-    pub fn as_unique(&self) -> Option<&Unique> {
+    pub fn as_unique(&self) -> Option<&Bind> {
         match self {
-            Value::Unique(u) => Some(u),
+            Value::Bind(u) => Some(u),
             _ => None,
         }
     }
@@ -646,7 +646,7 @@ impl Value {
             | Value::IntSCarry(_)
             | Value::IntSBorrow(_) => 1,
             Value::Int2Comp(Int2CompExpr(_, s)) => *s,
-            Value::Unique(u) => u.size(),
+            Value::Bind(u) => u.size(),
             Value::Top => 8, // conservative default
         }
     }
@@ -677,15 +677,15 @@ impl Value {
         Value::Const(Const(vn))
     }
 
-    /// Construct a fresh [`Value::Unique`] with the given size in bytes.
+    /// Construct a fresh [`Value::Bind`] with the given size in bytes.
     ///
     /// Each call draws the next value from a shared global [`AtomicU64`] counter,
     /// so the returned id is guaranteed to be unique within the process lifetime.
-    /// The only other way to obtain a `Value::Unique` is by cloning an existing one,
+    /// The only other way to obtain a `Value::Bind` is by cloning an existing one,
     /// which preserves the original id.
-    pub fn fresh_unique(size: usize) -> Self {
-        let id = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
-        Value::Unique(Unique(id, size))
+    pub fn fresh_bind(size: usize) -> Self {
+        let id = BIND_COUNTER.fetch_add(1, Ordering::Relaxed);
+        Value::Bind(Bind(id, size))
     }
 
     /// Construct a `Choice(...)` node from two children. Size is derived from children.
@@ -902,7 +902,7 @@ impl Value {
             Value::IntCarry(_) => 30,
             Value::IntSCarry(_) => 31,
             Value::IntSBorrow(_) => 32,
-            Value::Unique(_) => 33,
+            Value::Bind(_) => 33,
         }
     }
 
@@ -976,7 +976,7 @@ impl Simplify for Value {
             Value::Entry(_)
             | Value::Offset(_)
             | Value::Const(_)
-            | Value::Unique(_)
+            | Value::Bind(_)
             | Value::Top => self.clone(),
         }
     }
@@ -1068,7 +1068,7 @@ impl Value {
             Value::Top => Value::Top,
 
             // Unique: opaque leaf — preserve identity, never substituted
-            Value::Unique(_) => self.clone(),
+            Value::Bind(_) => self.clone(),
 
             // Offset: substitute the base entry
             Value::Offset(_) => self.clone(),
@@ -2564,7 +2564,7 @@ impl JingleDisplay for Value {
                 b.as_ref().fmt_jingle(f, info)?;
                 write!(f, ")")
             }
-            Value::Unique(u) => write!(f, "unique({}, {})", u.id(), u.size()),
+            Value::Bind(u) => write!(f, "unique({}, {})", u.id(), u.size()),
             Value::Top => write!(f, "⊤"),
         }
     }
@@ -2707,7 +2707,7 @@ impl std::fmt::Display for Value {
             Value::IntSBorrow(IntSBorrow(a, b)) => {
                 write!(f, "sborrow({}, {})", a.as_ref(), b.as_ref())
             }
-            Value::Unique(u) => write!(f, "unique({}, {})", u.id(), u.size()),
+            Value::Bind(u) => write!(f, "unique({}, {})", u.id(), u.size()),
             Value::Top => {
                 // Special top symbol
                 write!(f, "⊤")
@@ -2856,7 +2856,7 @@ impl std::fmt::LowerHex for Value {
             Value::IntSBorrow(IntSBorrow(a, b)) => {
                 write!(f, "sborrow({:x}, {:x})", a.as_ref(), b.as_ref())
             }
-            Value::Unique(u) => write!(f, "unique({:x}, {})", u.id(), u.size()),
+            Value::Bind(u) => write!(f, "unique({:x}, {})", u.id(), u.size()),
             Value::Top => write!(f, "⊤"),
         }
     }

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -7,11 +7,16 @@ use jingle_sleigh::{SleighArchInfo, VarNode};
 use std::{
     borrow::Borrow,
     ops::{BitAnd, BitXor, Deref},
+    sync::atomic::{AtomicU64, Ordering},
 };
 use std::{
     fmt::Formatter,
     ops::{Add, Mul, Sub},
 };
+
+/// Global atomic counter used exclusively by [`Value::fresh_unique`] to mint
+/// monotonically-increasing, globally-unique identifiers.
+static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 mod sealed {
     pub trait Sealed {}
@@ -250,6 +255,26 @@ pub struct SignExtend(pub Intern<Value>, pub usize);
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct Extract(pub Intern<Value>, pub usize, pub usize);
 
+/// A globally-unique opaque value with an associated size in bytes.
+///
+/// The only way to create a fresh `Unique` (other than cloning an existing one)
+/// is via [`Value::fresh_unique`], which draws a monotonically-increasing id
+/// from a shared atomic counter.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Unique(u64, usize);
+
+impl Unique {
+    /// The globally-unique numeric identifier for this value.
+    pub fn id(&self) -> u64 {
+        self.0
+    }
+
+    /// The size in bytes associated with this unique value.
+    pub fn size(&self) -> usize {
+        self.1
+    }
+}
+
 impl AsRef<VarNode> for Const {
     fn as_ref(&self) -> &VarNode {
         &self.0
@@ -308,6 +333,10 @@ pub enum Value {
     IntSCarry(IntSCarry),
     IntSBorrow(IntSBorrow),
 
+    /// A globally-unique opaque value. Construct exclusively via
+    /// [`Value::fresh_unique`]; cloning an existing `Unique` preserves the id.
+    Unique(Unique),
+
     Top,
 }
 
@@ -354,6 +383,14 @@ impl Value {
     pub fn as_offset(&self) -> Option<&Offset> {
         match self {
             Value::Offset(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Accessor for the `Unique` variant.
+    pub fn as_unique(&self) -> Option<&Unique> {
+        match self {
+            Value::Unique(u) => Some(u),
             _ => None,
         }
     }
@@ -609,6 +646,7 @@ impl Value {
             | Value::IntSCarry(_)
             | Value::IntSBorrow(_) => 1,
             Value::Int2Comp(Int2CompExpr(_, s)) => *s,
+            Value::Unique(u) => u.size(),
             Value::Top => 8, // conservative default
         }
     }
@@ -637,6 +675,17 @@ impl Value {
     /// Construct a `Const(...)` directly from a `VarNode` (already contains size).
     pub fn const_from_varnode(vn: VarNode) -> Self {
         Value::Const(Const(vn))
+    }
+
+    /// Construct a fresh [`Value::Unique`] with the given size in bytes.
+    ///
+    /// Each call draws the next value from a shared global [`AtomicU64`] counter,
+    /// so the returned id is guaranteed to be unique within the process lifetime.
+    /// The only other way to obtain a `Value::Unique` is by cloning an existing one,
+    /// which preserves the original id.
+    pub fn fresh_unique(size: usize) -> Self {
+        let id = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        Value::Unique(Unique(id, size))
     }
 
     /// Construct a `Choice(...)` node from two children. Size is derived from children.
@@ -853,6 +902,7 @@ impl Value {
             Value::IntCarry(_) => 30,
             Value::IntSCarry(_) => 31,
             Value::IntSBorrow(_) => 32,
+            Value::Unique(_) => 33,
         }
     }
 
@@ -923,7 +973,11 @@ impl Simplify for Value {
             Value::IntCarry(expr) => expr.simplify(),
             Value::IntSCarry(expr) => expr.simplify(),
             Value::IntSBorrow(expr) => expr.simplify(),
-            Value::Entry(_) | Value::Offset(_) | Value::Const(_) | Value::Top => self.clone(),
+            Value::Entry(_)
+            | Value::Offset(_)
+            | Value::Const(_)
+            | Value::Unique(_)
+            | Value::Top => self.clone(),
         }
     }
 }
@@ -1012,6 +1066,9 @@ impl Value {
             }
             Value::Const(_) => self.clone(),
             Value::Top => Value::Top,
+
+            // Unique: opaque leaf — preserve identity, never substituted
+            Value::Unique(_) => self.clone(),
 
             // Offset: substitute the base entry
             Value::Offset(_) => self.clone(),
@@ -2507,6 +2564,7 @@ impl JingleDisplay for Value {
                 b.as_ref().fmt_jingle(f, info)?;
                 write!(f, ")")
             }
+            Value::Unique(u) => write!(f, "unique({}, {})", u.id(), u.size()),
             Value::Top => write!(f, "⊤"),
         }
     }
@@ -2649,6 +2707,7 @@ impl std::fmt::Display for Value {
             Value::IntSBorrow(IntSBorrow(a, b)) => {
                 write!(f, "sborrow({}, {})", a.as_ref(), b.as_ref())
             }
+            Value::Unique(u) => write!(f, "unique({}, {})", u.id(), u.size()),
             Value::Top => {
                 // Special top symbol
                 write!(f, "⊤")
@@ -2797,6 +2856,7 @@ impl std::fmt::LowerHex for Value {
             Value::IntSBorrow(IntSBorrow(a, b)) => {
                 write!(f, "sborrow({:x}, {:x})", a.as_ref(), b.as_ref())
             }
+            Value::Unique(u) => write!(f, "unique({:x}, {})", u.id(), u.size()),
             Value::Top => write!(f, "⊤"),
         }
     }


### PR DESCRIPTION
Useful for tracking unique values in an analysis.

Without this I was over-relying on `Value::Top` to express something I needed to track but did not have a concrete value for.