### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.22](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.21...jingle-v0.6.22) - 2026-05-06
+
+### Added
+
+- add srde impls for value types ([#263](https://github.com/toolCHAINZ/jingle/pull/263))
+
+### Fixed
+
+- rename as_unique to as_bind and update display ([#262](https://github.com/toolCHAINZ/jingle/pull/262))
+
 ## [0.6.21](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.20...jingle-v0.6.21) - 2026-05-06
 
 ### Fixed

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.8...jingle_sleigh-v0.5.9) - 2026-05-06
+
+### Added
+
+- add srde impls for value types ([#263](https://github.com/toolCHAINZ/jingle/pull/263))
+
 ## [0.5.8](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.7...jingle_sleigh-v0.5.8) - 2026-04-30
 
 ### Added

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.5.8 -> 0.5.9 (✓ API compatible changes)
* `jingle`: 0.6.21 -> 0.6.22 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.5.9](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.8...jingle_sleigh-v0.5.9) - 2026-05-06

### Added

- add srde impls for value types ([#263](https://github.com/toolCHAINZ/jingle/pull/263))
</blockquote>

## `jingle`

<blockquote>

## [0.6.22](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.21...jingle-v0.6.22) - 2026-05-06

### Added

- add srde impls for value types ([#263](https://github.com/toolCHAINZ/jingle/pull/263))

### Fixed

- rename as_unique to as_bind and update display ([#262](https://github.com/toolCHAINZ/jingle/pull/262))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).