### PR TITLE
fix: add pointer space index to Load structure and related functions

### DIFF
--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -104,7 +104,11 @@ impl ValuationState {
                 let val = Value::from_varnode_or_entry(self, input);
                 let pv = Value::from_varnode_or_entry(self, ptr);
                 let data_size = input.size();
-                let loc = Value::Load(Load(Intern::new(pv.simplify()), data_size));
+                let loc = Value::Load(Load(
+                    Intern::new(pv.simplify()),
+                    data_size,
+                    output.pointer_space_index() as u8,
+                ));
                 new_state.valuation.add(loc, val);
             }
 
@@ -260,7 +264,11 @@ impl ValuationState {
                 let ptr = &input.pointer_location();
                 let pv = Value::from_varnode_or_entry(self, ptr);
                 if let Some(GeneralizedVarNode::Direct(output_vn)) = op.output() {
-                    let load_expr = Value::Load(Load(Intern::new(pv.simplify()), output_vn.size()));
+                    let load_expr = Value::Load(Load(
+                        Intern::new(pv.simplify()),
+                        output_vn.size(),
+                        input.pointer_space_index() as u8,
+                    ));
                     if let Some(v) = self.valuation.indirect_writes.get(&load_expr) {
                         new_state.valuation.add(output_vn, v.clone());
                     } else {

--- a/jingle/src/analysis/valuation/simple/valuation.rs
+++ b/jingle/src/analysis/valuation/simple/valuation.rs
@@ -179,9 +179,9 @@ impl ValuationSet {
         for (sym_expr, value) in &self.indirect_writes {
             let substituted_key = match sym_expr {
                 // in practice, this will always be hit
-                Value::Load(Load(ptr, size)) => {
+                Value::Load(Load(ptr, size, space)) => {
                     let sub_ptr = ptr.substitute(context);
-                    Value::Load(Load(Intern::new(sub_ptr), *size))
+                    Value::Load(Load(Intern::new(sub_ptr), *size, *space))
                 }
                 a => a.substitute(context),
             };
@@ -813,6 +813,7 @@ mod tests {
         let load_key = Value::Load(crate::analysis::valuation::simple::value::Load(
             internment::Intern::new(Value::const_(100, 8)),
             8,
+            1,
         ));
         valuation
             .indirect_writes
@@ -958,6 +959,7 @@ mod tests {
         let load_expr = Value::Load(crate::analysis::valuation::simple::value::Load(
             internment::Intern::new(rsp_plus_4.clone()),
             8,
+            1,
         ));
 
         let mut val1 = ValuationSet::new();
@@ -980,6 +982,7 @@ mod tests {
         let expected_key = Value::Load(crate::analysis::valuation::simple::value::Load(
             internment::Intern::new(Value::const_(0x1004, 8)),
             8,
+            1,
         ));
 
         assert_eq!(
@@ -997,6 +1000,7 @@ mod tests {
         let load_expr = Value::Load(crate::analysis::valuation::simple::value::Load(
             internment::Intern::new(Value::const_(0x1000, 8)),
             8,
+            1,
         ));
 
         let mut val1 = ValuationSet::new();

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -2493,7 +2493,9 @@ impl JingleDisplay for Value {
                     .ok_or(std::fmt::Error)?
                     .name
                     .as_str();
-                write!(f, "*[{name}]:{}:{size}", a.as_ref().display(info))
+                write!(f, "*[{name}]")?;
+                fmt_operand_jingle(f, a.as_ref(), info)?;
+                write!(f, ":{size}")
             }
             Value::ZeroExtend(ZeroExtend(a, s)) => {
                 write!(f, "zext(")?;
@@ -2662,7 +2664,9 @@ impl std::fmt::Display for Value {
             }
             Value::Load(Load(a, size, space)) => {
                 // Load(child)
-                write!(f, "*[({space})]{}:{size}", a.as_ref())
+                write!(f, "*[{space}]")?;
+                fmt_operand(f, a.as_ref())?;
+                write!(f, ":{size}")
             }
             Value::ZeroExtend(ZeroExtend(a, s)) => write!(f, "zext({}, {s})", a.as_ref()),
             Value::SignExtend(SignExtend(a, s)) => write!(f, "sext({}, {s})", a.as_ref()),

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -242,7 +242,7 @@ pub struct IntSBorrow(pub Intern<Value>, pub Intern<Value>);
 
 /// A load of a certain size from a pointer with a certain value
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Load(pub Intern<Value>, pub usize);
+pub struct Load(pub Intern<Value>, pub usize, pub u8);
 
 /// A zero-extension of the inner value to `output_size` bytes
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -633,7 +633,7 @@ impl Value {
             | Value::IntRightShift(IntRightShiftExpr(_, _, s))
             | Value::IntSignedRightShift(IntSignedRightShiftExpr(_, _, s)) => *s,
             Value::BoolNegate(_) | Value::BoolAnd(_) | Value::BoolOr(_) | Value::BoolXor(_) => 1,
-            Value::Load(Load(_, s)) => *s,
+            Value::Load(Load(_, s, _)) => *s,
             Value::ZeroExtend(ZeroExtend(_, s)) | Value::SignExtend(SignExtend(_, s)) => *s,
             Value::Extract(Extract(_, _, s)) => *s,
             Value::IntSLess(_)
@@ -743,9 +743,9 @@ impl Value {
     }
 
     /// Construct a `Load(...)` node from a child.
-    pub fn load(child: impl IntoInternedValue, size: usize) -> Self {
+    pub fn load(child: impl IntoInternedValue, size: usize, space: u8) -> Self {
         let child = child.into_interned();
-        Value::Load(Load(child, size))
+        Value::Load(Load(child, size, space))
     }
 
     /// Construct an `IntEqual(...)` node from two children.
@@ -1073,14 +1073,14 @@ impl Value {
             Value::Offset(_) => self.clone(),
 
             // Load: substitute the pointer, then check if the result is in indirect_writes
-            Value::Load(Load(ptr, size)) => {
+            Value::Load(Load(ptr, size, space)) => {
                 let subst_ptr = ptr.as_ref().substitute(context);
                 // Look up the substituted pointer in indirect writes
                 context
                     .indirect_writes
-                    .get(&Value::load(&subst_ptr, *size))
+                    .get(&Value::load(&subst_ptr, *size, *space))
                     .map(|v| v.substitute(context))
-                    .unwrap_or_else(|| Value::Load(Load(Intern::new(subst_ptr), *size)))
+                    .unwrap_or_else(|| Value::Load(Load(Intern::new(subst_ptr), *size, *space)))
             }
 
             // Binary operators: substitute both operands
@@ -1964,7 +1964,7 @@ impl Simplify for Load {
         let a_s = a_intern.as_ref().simplify();
 
         // keep the same size as recorded on this Load node
-        Value::Load(Load(Intern::new(a_s), self.1))
+        Value::Load(Load(Intern::new(a_s), self.1, self.2))
     }
 }
 
@@ -2487,7 +2487,14 @@ impl JingleDisplay for Value {
                 write!(f, "s>>")?;
                 fmt_operand_jingle(f, b.as_ref(), info)
             }
-            Value::Load(Load(a, _)) => write!(f, "Load({})", a.as_ref().display(info)),
+            Value::Load(Load(a, size, space)) => {
+                let name = info
+                    .get_space(*space as usize)
+                    .ok_or(std::fmt::Error)?
+                    .name
+                    .as_str();
+                write!(f, "*[{name}]:{}:{size}", a.as_ref().display(info))
+            }
             Value::ZeroExtend(ZeroExtend(a, s)) => {
                 write!(f, "zext(")?;
                 a.as_ref().fmt_jingle(f, info)?;
@@ -2653,9 +2660,9 @@ impl std::fmt::Display for Value {
                 write!(f, "s>>")?;
                 fmt_operand(f, b.as_ref())
             }
-            Value::Load(Load(a, _)) => {
+            Value::Load(Load(a, size, space)) => {
                 // Load(child)
-                write!(f, "Load({})", a.as_ref())
+                write!(f, "*[({space})]{}:{size}", a.as_ref())
             }
             Value::ZeroExtend(ZeroExtend(a, s)) => write!(f, "zext({}, {s})", a.as_ref()),
             Value::SignExtend(SignExtend(a, s)) => write!(f, "sext({}, {s})", a.as_ref()),
@@ -2799,8 +2806,8 @@ impl std::fmt::LowerHex for Value {
                 write!(f, "s>>")?;
                 fmt_operand_hex(f, b.as_ref())
             }
-            Value::Load(Load(a, _)) => {
-                write!(f, "Load({:x})", a.as_ref())
+            Value::Load(Load(a, size, space)) => {
+                write!(f, "*[{space:x}]{:x}:{size:x}", a.as_ref())
             }
             Value::ZeroExtend(ZeroExtend(a, s)) => {
                 write!(f, "zext({:x}, {s})", a.as_ref())

--- a/jingle/src/analysis/valuation/simple/value_tests.rs
+++ b/jingle/src/analysis/valuation/simple/value_tests.rs
@@ -625,7 +625,7 @@ fn substitute_bool_nodes_and_simplifies() {
 
 #[test]
 fn load_top_propagation() {
-    let result = Value::load(Value::Top, 8).simplify();
+    let result = Value::load(Value::Top, 8, 1).simplify();
     assert_ne!(result, Value::Top);
 }
 
@@ -633,7 +633,7 @@ fn load_top_propagation() {
 fn load_simplifies_child() {
     // load(5 + 3)  =>  Load(const_8, _)
     let child = Value::const_(5, 8) + Value::const_(3, 8);
-    let result = Value::load(child, 8).simplify();
+    let result = Value::load(child, 8, 1).simplify();
     let load = result.as_load().expect("expected Load");
     assert_eq!(load.0.as_ref().as_const_value(), Some(8));
 }
@@ -641,7 +641,7 @@ fn load_simplifies_child() {
 #[test]
 fn load_preserves_size() {
     let child = Value::entry(vn_a());
-    let node = Value::Load(Load(Intern::new(child), 4));
+    let node = Value::Load(Load(Intern::new(child), 4, 1));
     let result = node.simplify();
     let load = result.as_load().expect("expected Load");
     assert_eq!(load.1, 4);


### PR DESCRIPTION
Value::Load was implicitly in the default code space, but it's always better to be explicit about this sort of thing. Now there's a nice u8 hanging out in Load denoting the pcode space it refers to.