### PR TITLE
fix: remove incorrect call modeling

### DIFF
--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -447,18 +447,7 @@ impl ValuationState {
                     new_state.valuation.direct_writes.remove(k);
                 }
             }
-            PcodeOperation::Call { call_info, .. } => {
-                if let Some(a) = call_info.iter().flat_map(|a| a.extrapop).next() {
-                    if let Some(stack) = self.arch_info.stack_pointer() {
-                        let stack_value = Value::from_varnode_or_entry(self, &stack);
-                        let shift_vn = VarNode::new_const(a as u64, stack.size());
-
-                        new_state
-                            .valuation
-                            .add(stack, stack_value + Value::const_from_varnode(shift_vn));
-                    }
-                }
-            }
+            PcodeOperation::Call { .. } => {}
             PcodeOperation::CallOther {
                 output: Some(a), ..
             } => {


### PR DESCRIPTION
There was some placeholder support for sleigh's shift/extrapop calling convention info, but it was being applied incorrectly. Disabling for now.