### PR TITLE
fix: ValuationSet now respects register sub-access

### DIFF
--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -736,11 +736,9 @@ mod tests {
             input1: VarNode::new_const(0, 4),
         });
 
-        let expected = Value::int_equal(
-            Value::entry(src) + Value::const_(1, 4),
-            Value::const_(0, 4),
-        )
-        .simplify();
+        let expected =
+            Value::int_equal(Value::entry(src) + Value::const_(1, 4), Value::const_(0, 4))
+                .simplify();
         assert_eq!(*state.get_value(&zf).expect("ZF should be set"), expected);
     }
 
@@ -762,11 +760,9 @@ mod tests {
             input1: VarNode::new_const(0, 2),
         });
 
-        let expected = Value::int_equal(
-            Value::extract(Value::entry(src), 2, 2),
-            Value::const_(0, 2),
-        )
-        .simplify();
+        let expected =
+            Value::int_equal(Value::extract(Value::entry(src), 2, 2), Value::const_(0, 2))
+                .simplify();
         assert_eq!(*state.get_value(&out).expect("out should be set"), expected);
     }
 }

--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -447,18 +447,7 @@ impl ValuationState {
                     new_state.valuation.direct_writes.remove(k);
                 }
             }
-            PcodeOperation::Call { call_info, .. } => {
-                if let Some(a) = call_info.iter().flat_map(|a| a.extrapop).next() {
-                    if let Some(stack) = self.arch_info.stack_pointer() {
-                        let stack_value = Value::from_varnode_or_entry(self, &stack);
-                        let shift_vn = VarNode::new_const(a as u64, stack.size());
-
-                        new_state
-                            .valuation
-                            .add(stack, stack_value + Value::const_from_varnode(shift_vn));
-                    }
-                }
-            }
+            PcodeOperation::Call { .. } => {}
             PcodeOperation::CallOther {
                 output: Some(a), ..
             } => {

--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -704,4 +704,69 @@ mod tests {
             Value::int_not_equal(Value::entry(reg(0x30, 8)), Value::entry(reg(0x40, 8))).simplify()
         );
     }
+
+    #[test]
+    fn transfer_read_sub_register_after_wider_zext_write() {
+        // EAX is written, then RAX = INT_ZEXT EAX (evicts EAX), then ZF = (EAX == 0).
+        // ZF must reflect the computed EAX value, not Entry(EAX).
+        let mut state = ValuationState::new(test_arch());
+        let eax = reg(0x0, 4);
+        let rax = reg(0x0, 8);
+        let zf = reg(0x100, 1);
+        let src = reg(0x200, 4);
+
+        state
+            .valuation
+            .add(eax, Value::entry(src) + Value::const_(1, 4));
+
+        // RAX = INT_ZEXT EAX — this evicts EAX from direct_writes
+        state = state.transfer_impl(&PcodeOperation::IntZExt {
+            input: eax,
+            output: rax,
+        });
+        assert!(
+            state.get_value(&eax).is_none(),
+            "EAX should be evicted after RAX write"
+        );
+
+        // ZF = (EAX == 0)
+        state = state.transfer_impl(&PcodeOperation::IntEqual {
+            output: zf,
+            input0: eax,
+            input1: VarNode::new_const(0, 4),
+        });
+
+        let expected = Value::int_equal(
+            Value::entry(src) + Value::const_(1, 4),
+            Value::const_(0, 4),
+        )
+        .simplify();
+        assert_eq!(*state.get_value(&zf).expect("ZF should be set"), expected);
+    }
+
+    #[test]
+    fn transfer_read_sub_register_nonzero_byte_offset() {
+        // Write a 4-byte register at offset 0, then read the upper 2 bytes (offset 2).
+        // The result should be extract(wider_val, 2, 2), not Entry(upper).
+        let mut state = ValuationState::new(test_arch());
+        let wide = reg(0x0, 4);
+        let upper = reg(0x2, 2); // bytes [2..4] of wide
+        let out = reg(0x100, 1);
+        let src = reg(0x200, 4);
+
+        state.valuation.add(wide, Value::entry(src));
+
+        state = state.transfer_impl(&PcodeOperation::IntEqual {
+            output: out,
+            input0: upper,
+            input1: VarNode::new_const(0, 2),
+        });
+
+        let expected = Value::int_equal(
+            Value::extract(Value::entry(src), 2, 2),
+            Value::const_(0, 2),
+        )
+        .simplify();
+        assert_eq!(*state.get_value(&out).expect("out should be set"), expected);
+    }
 }

--- a/jingle/src/analysis/valuation/simple/value.rs
+++ b/jingle/src/analysis/valuation/simple/value.rs
@@ -2883,6 +2883,16 @@ impl Value {
             Value::const_from_varnode(*vn)
         } else if let Some(v) = state.valuation.direct_writes.get(vn) {
             v.clone()
+        } else if let Some((wider_vn, wider_val)) = state
+            .valuation
+            .direct_writes
+            .items()
+            .find(|(w, _)| w.covers(vn) && *w != vn)
+        {
+            // A wider register covers this varnode (e.g. RAX was written after EAX was evicted by
+            // the write). Emit an Extract so simplify() can reduce extract(zext(x, 8), 0, 4) → x.
+            let byte_offset = (vn.offset() - wider_vn.offset()) as usize;
+            Value::extract(wider_val.clone(), byte_offset, vn.size())
         } else {
             Value::Entry(Entry(*vn))
         }


### PR DESCRIPTION
Certain patterns of pcode would previously cause incomplete values to be fetched from the varnode map. This could happen with certain intra-instruction subregister accesses (e.g. `EAX = (value), RAX = zext(EAX)` would evict the eax valuation and cause an incorrect result on subsequent reads to EAX). This is now tracked correctly so the example case would instead be `value`