### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.29](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.28...jingle-v0.6.29) - 2026-05-17
+
+### Fixed
+
+- ValuationSet now respects register sub-access ([#278](https://github.com/toolCHAINZ/jingle/pull/278))
+
 ## [0.6.28](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.27...jingle-v0.6.28) - 2026-05-13
 
 ### Fixed

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.11](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.10...jingle_sleigh-v0.5.11) - 2026-05-17
+
+### Other
+
+- Fix image load wrapping add ([#280](https://github.com/toolCHAINZ/jingle/pull/280))
+
 ## [0.5.10](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.9...jingle_sleigh-v0.5.10) - 2026-05-07
 
 ### Other

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.5.10 -> 0.5.11 (✓ API compatible changes)
* `jingle`: 0.6.28 -> 0.6.29 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.5.11](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.10...jingle_sleigh-v0.5.11) - 2026-05-17

### Other

- Fix image load wrapping add ([#280](https://github.com/toolCHAINZ/jingle/pull/280))
</blockquote>

## `jingle`

<blockquote>

## [0.6.29](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.28...jingle-v0.6.29) - 2026-05-17

### Fixed

- ValuationSet now respects register sub-access ([#278](https://github.com/toolCHAINZ/jingle/pull/278))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).