### PR TITLE
Fix image load wrapping add

### DIFF
--- a/jingle/src/analysis/valuation/simple/mod.rs
+++ b/jingle/src/analysis/valuation/simple/mod.rs
@@ -447,18 +447,7 @@ impl ValuationState {
                     new_state.valuation.direct_writes.remove(k);
                 }
             }
-            PcodeOperation::Call { call_info, .. } => {
-                if let Some(a) = call_info.iter().flat_map(|a| a.extrapop).next() {
-                    if let Some(stack) = self.arch_info.stack_pointer() {
-                        let stack_value = Value::from_varnode_or_entry(self, &stack);
-                        let shift_vn = VarNode::new_const(a as u64, stack.size());
-
-                        new_state
-                            .valuation
-                            .add(stack, stack_value + Value::const_from_varnode(shift_vn));
-                    }
-                }
-            }
+            PcodeOperation::Call { .. } => {}
             PcodeOperation::CallOther {
                 output: Some(a), ..
             } => {

--- a/jingle_sleigh/src/context/image/gimli.rs
+++ b/jingle_sleigh/src/context/image/gimli.rs
@@ -108,13 +108,15 @@ impl SleighImageCore for OwnedFile {
         let mut written = 0;
         output.fill(0);
         let output_start_addr = vn.offset() as usize;
-        let output_end_addr = output_start_addr + vn.size();
+        let Some(output_end_addr) = output_start_addr.checked_add(vn.size()) else {
+            return 0;
+        };
         if let Some(x) = self.image_sections().filter(|s| s.perms.exec).find(|s| {
             output_start_addr >= s.base_address
-                && output_start_addr < (s.base_address + s.data.len())
+                && output_start_addr < s.base_address.saturating_add(s.data.len())
         }) {
             let input_start_addr = x.base_address;
-            let input_end_addr = input_start_addr + x.data.len();
+            let input_end_addr = input_start_addr.saturating_add(x.data.len());
             let start_addr = max(input_start_addr, output_start_addr);
             let end_addr = max(min(input_end_addr, output_end_addr), start_addr);
             if end_addr > start_addr {
@@ -132,9 +134,12 @@ impl SleighImageCore for OwnedFile {
     }
 
     fn has_full_range(&self, vn: &VarNode) -> bool {
+        let Some(vn_end) = (vn.offset() as usize).checked_add(vn.size()) else {
+            return false;
+        };
         self.image_sections().filter(|s| s.perms.exec).any(|s| {
             s.base_address <= vn.offset() as usize
-                && (s.base_address + s.data.len()) >= (vn.offset() as usize + vn.size())
+                && s.base_address.saturating_add(s.data.len()) >= vn_end
         })
     }
 }
@@ -156,14 +161,16 @@ impl<'a> SleighImageCore for File<'a, &'a [u8]> {
         let mut written = 0;
         output.fill(0);
         let output_start_addr = vn.offset() as usize;
-        let output_end_addr = output_start_addr + vn.size();
+        let Some(output_end_addr) = output_start_addr.checked_add(vn.size()) else {
+            return 0;
+        };
         if let Some(x) = self.sections().find(|s| {
             output_start_addr >= s.address() as usize
                 && output_start_addr < (s.address() + s.size()) as usize
         }) {
             if let Ok(data) = x.data() {
                 let input_start_addr = x.address() as usize;
-                let input_end_addr = input_start_addr + data.len();
+                let input_end_addr = input_start_addr.saturating_add(data.len());
                 let start_addr = max(input_start_addr, output_start_addr);
                 let end_addr = max(min(input_end_addr, output_end_addr), start_addr);
                 if end_addr > start_addr {
@@ -182,9 +189,12 @@ impl<'a> SleighImageCore for File<'a, &'a [u8]> {
     }
 
     fn has_full_range(&self, vn: &VarNode) -> bool {
+        let Some(vn_end) = vn.offset().checked_add(vn.size() as u64) else {
+            return false;
+        };
         self.sections().any(|s| {
             s.address() <= vn.offset()
-                && (s.address() + s.size()) >= (vn.offset() + vn.size() as u64)
+                && s.address().saturating_add(s.size()) >= vn_end
         })
     }
 }

--- a/jingle_sleigh/src/context/image/gimli.rs
+++ b/jingle_sleigh/src/context/image/gimli.rs
@@ -192,10 +192,8 @@ impl<'a> SleighImageCore for File<'a, &'a [u8]> {
         let Some(vn_end) = vn.offset().checked_add(vn.size() as u64) else {
             return false;
         };
-        self.sections().any(|s| {
-            s.address() <= vn.offset()
-                && s.address().saturating_add(s.size()) >= vn_end
-        })
+        self.sections()
+            .any(|s| s.address() <= vn.offset() && s.address().saturating_add(s.size()) >= vn_end)
     }
 }
 

--- a/jingle_sleigh/src/context/loaded.rs
+++ b/jingle_sleigh/src/context/loaded.rs
@@ -106,6 +106,9 @@ impl<'a> LoadedSleighContext<'a> {
     /// Read the byte range specified by the given [`VarNode`] from the configured image provider.
     pub fn read_bytes(&self, vn: &VarNode) -> Option<Vec<u8>> {
         if vn.space_index() == self.arch_info.default_code_space_index() {
+            if vn.offset() < self.get_base_address() {
+                return None;
+            }
             self.img.provider.get_bytes(&self.adjust_varnode_vma(vn))
         } else {
             None

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -81,12 +81,18 @@ impl<'a> ImageFFI<'a> {
         if addr.space_index() != self.space_index as usize {
             return 0;
         }
+        if addr.offset() < self.base_offset {
+            return 0;
+        }
         let adjusted = self.adjust_varnode_vma(&addr);
         self.provider.load(&adjusted, out)
     }
 
     pub(crate) fn has_range(&self, vn: &VarNode) -> bool {
         if vn.space_index() != self.space_index as usize {
+            return false;
+        }
+        if vn.offset() < self.base_offset {
             return false;
         }
         self.provider.has_full_range(&self.adjust_varnode_vma(vn))

--- a/jingle_sleigh/src/varnode/mod.rs
+++ b/jingle_sleigh/src/varnode/mod.rs
@@ -194,7 +194,7 @@ impl From<&VarNode> for Range<usize> {
     fn from(value: &VarNode) -> Self {
         Range {
             start: value.offset as usize,
-            end: value.offset as usize + value.size,
+            end: (value.offset as usize).saturating_add(value.size()),
         }
     }
 }


### PR DESCRIPTION
It was possible to ask sleigh to disassemble across wrapping addresses before (e.g. 8 bytes at `0xfffffffffffffffe`). I don't know that this is really "proper" behavior, but now all the math for that kind of computation uses saturating adds and there's some sanity bounds checking.