### PR TITLE
chore: release

### DIFF
--- a/jingle/CHANGELOG.md
+++ b/jingle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.36](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.35...jingle-v0.6.36) - 2026-05-29
+
+### Other
+
+- use im::OrdMap instead of std::BTreeMap for value maps ([#294](https://github.com/toolCHAINZ/jingle/pull/294))
+
 ## [0.6.35](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.34...jingle-v0.6.35) - 2026-05-27
 
 ### Fixed

--- a/jingle/Cargo.toml
+++ b/jingle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle"
-version = "0.6.35"
+version = "0.6.36"
 edition = "2024"
 description = "SMT Modeling for Ghidra's PCODE"
 homepage = "https://github.com/toolCHAINZ/jingle"

--- a/jingle_sleigh/CHANGELOG.md
+++ b/jingle_sleigh/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.11...jingle_sleigh-v0.5.12) - 2026-05-29
+
+### Other
+
+- use im::OrdMap instead of std::BTreeMap for value maps ([#294](https://github.com/toolCHAINZ/jingle/pull/294))
+
 ## [0.5.11](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.10...jingle_sleigh-v0.5.11) - 2026-05-17
 
 ### Other

--- a/jingle_sleigh/Cargo.toml
+++ b/jingle_sleigh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jingle_sleigh"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2024"
 description = "An FFI layer for Ghidra's SLEIGH"
 homepage = "https://github.com/toolCHAINZ/jingle"


### PR DESCRIPTION



## 🤖 New release

* `jingle_sleigh`: 0.5.11 -> 0.5.12 (✓ API compatible changes)
* `jingle`: 0.6.35 -> 0.6.36 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jingle_sleigh`

<blockquote>

## [0.5.12](https://github.com/toolCHAINZ/jingle/compare/jingle_sleigh-v0.5.11...jingle_sleigh-v0.5.12) - 2026-05-29

### Other

- use im::OrdMap instead of std::BTreeMap for value maps ([#294](https://github.com/toolCHAINZ/jingle/pull/294))
</blockquote>

## `jingle`

<blockquote>

## [0.6.36](https://github.com/toolCHAINZ/jingle/compare/jingle-v0.6.35...jingle-v0.6.36) - 2026-05-29

### Other

- use im::OrdMap instead of std::BTreeMap for value maps ([#294](https://github.com/toolCHAINZ/jingle/pull/294))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).