### PR TITLE
refactor: divorce PcodeAddressLattice from Value

### DIFF
--- a/jingle/src/analysis/cpa/lattice/pcode.rs
+++ b/jingle/src/analysis/cpa/lattice/pcode.rs
@@ -2,7 +2,6 @@ use crate::analysis::cpa::lattice::JoinSemiLattice;
 use crate::analysis::cpa::state::{
     AbstractState, LocationState, MergeOutcome, PcodeLocation, Successor,
 };
-use crate::analysis::valuation::Value;
 use crate::display::JingleDisplay;
 use crate::modeling::machine::cpu::concrete::ConcretePcodeAddress;
 use jingle_sleigh::{IndirectVarNode, PcodeOperation};
@@ -17,13 +16,11 @@ use std::iter::{empty, once};
 /// Variants:
 /// - `Const(addr)` — a concrete pcode address (like `FlatLattice::Value`)
 /// - `Indirect(ivn)` — raw output of the transfer function for indirect branches
-/// - `Computed(sv)` — resolved by valuation strengthening
 /// - `Top` — unknown / multiple locations
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PcodeAddressLattice {
     Const(ConcretePcodeAddress),
     Indirect(IndirectVarNode),
-    Computed(Value),
     Top,
 }
 
@@ -36,7 +33,6 @@ impl JingleDisplay for PcodeAddressLattice {
         match self {
             PcodeAddressLattice::Const(addr) => write!(f, "{:x}", addr),
             PcodeAddressLattice::Indirect(ivn) => ivn.fmt_jingle(f, info),
-            PcodeAddressLattice::Computed(sv) => sv.fmt_jingle(f, info),
             PcodeAddressLattice::Top => write!(f, "Top"),
         }
     }
@@ -53,10 +49,6 @@ impl Debug for PcodeAddressLattice {
                 .debug_tuple("PcodeAddressLattice::Indirect")
                 .field(&format_args!("{:?}", ivn))
                 .finish(),
-            PcodeAddressLattice::Computed(c) => f
-                .debug_tuple("PcodeAddressLattice::Computed")
-                .field(&format_args!("{:?}", c))
-                .finish(),
             PcodeAddressLattice::Top => write!(f, "PcodeAddressLattice::Top"),
         }
     }
@@ -70,9 +62,6 @@ impl LowerHex for PcodeAddressLattice {
             PcodeAddressLattice::Const(a) => write!(f, "PcodeAddressLattice::Const({:x})", a),
             PcodeAddressLattice::Indirect(ivn) => {
                 write!(f, "PcodeAddressLattice::Indirect({:x})", ivn)
-            }
-            PcodeAddressLattice::Computed(sv) => {
-                write!(f, "PcodeAddressLattice::Computed({:x})", sv)
             }
             PcodeAddressLattice::Top => write!(f, "PcodeAddressLattice::Top"),
         }
@@ -120,13 +109,6 @@ impl PartialOrd for PcodeAddressLattice {
                     None
                 }
             }
-            (Self::Computed(x), Self::Computed(y)) => {
-                if x == y {
-                    Some(Ordering::Equal)
-                } else {
-                    None
-                }
-            }
             // Different kinds are incomparable
             _ => None,
         }
@@ -144,11 +126,6 @@ impl JoinSemiLattice for PcodeAddressLattice {
                 }
             }
             (Self::Indirect(x), Self::Indirect(y)) => {
-                if x != y {
-                    *self = Self::Top;
-                }
-            }
-            (Self::Computed(x), Self::Computed(y)) => {
                 if x != y {
                     *self = Self::Top;
                 }
@@ -183,9 +160,7 @@ impl AbstractState for PcodeAddressLattice {
 
         match self {
             PcodeAddressLattice::Const(a) => a.transfer(op).into_iter().map(Self::Const).into(),
-            PcodeAddressLattice::Indirect(_)
-            | PcodeAddressLattice::Computed(_)
-            | PcodeAddressLattice::Top => empty().into(),
+            PcodeAddressLattice::Indirect(_) | PcodeAddressLattice::Top => empty().into(),
         }
     }
 }
@@ -203,9 +178,7 @@ impl LocationState for PcodeAddressLattice {
     ) -> Vec<(crate::analysis::pcode_store::PcodeOpRef<'op>, Self)> {
         let Some(op) = (match self {
             PcodeAddressLattice::Const(a) => store.get_pcode_op_at(a),
-            PcodeAddressLattice::Indirect(_)
-            | PcodeAddressLattice::Computed(_)
-            | PcodeAddressLattice::Top => None,
+            PcodeAddressLattice::Indirect(_) | PcodeAddressLattice::Top => None,
         }) else {
             return vec![];
         };
@@ -223,7 +196,6 @@ impl Display for PcodeAddressLattice {
                 write!(f, "{:x}", concrete_pcode_address)
             }
             PcodeAddressLattice::Indirect(ivn) => write!(f, "{}", ivn),
-            PcodeAddressLattice::Computed(sv) => write!(f, "{}", sv),
             PcodeAddressLattice::Top => write!(f, "Top"),
         }
     }

--- a/jingle/src/analysis/location/basic/state.rs
+++ b/jingle/src/analysis/location/basic/state.rs
@@ -39,6 +39,11 @@ pub enum CallBehavior {
 pub struct BasicLocationState {
     inner: PcodeAddressLattice,
     call_behavior: CallBehavior,
+    /// Set by `strengthen_from_valuation` when an indirect branch resolves to a
+    /// symbolic (non-constant) value. The inner address remains `Indirect(ivn)`
+    /// for lattice ordering purposes; this field carries the resolved expression
+    /// for consumers that want it (e.g. CFG model IDs).
+    computed: Option<Value>,
 }
 
 impl BasicLocationState {
@@ -46,6 +51,7 @@ impl BasicLocationState {
         Self {
             inner: addr,
             call_behavior,
+            computed: None,
         }
     }
 
@@ -53,6 +59,7 @@ impl BasicLocationState {
         Self {
             inner: PcodeAddressLattice::Const(addr),
             call_behavior,
+            computed: None,
         }
     }
 
@@ -60,6 +67,7 @@ impl BasicLocationState {
         Self {
             inner: PcodeAddressLattice::Top,
             call_behavior,
+            computed: None,
         }
     }
 
@@ -80,6 +88,7 @@ impl IntoState<BasicLocationAnalysis> for ConcretePcodeAddress {
         BasicLocationState {
             call_behavior: c.call_behavior,
             inner: PcodeAddressLattice::Const(self),
+            computed: None,
         }
     }
 }
@@ -116,16 +125,24 @@ impl LowerHex for BasicLocationState {
 impl PartialOrd for BasicLocationState {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.call_behavior != other.call_behavior {
-            None
-        } else {
-            self.inner.partial_cmp(&other.inner)
+            return None;
+        }
+        match self.inner.partial_cmp(&other.inner) {
+            Some(Ordering::Equal) if self.computed != other.computed => None,
+            other => other,
         }
     }
 }
 
 impl JoinSemiLattice for BasicLocationState {
     fn join(&mut self, other: &Self) {
-        self.inner.join(&other.inner);
+        if self.computed != other.computed {
+            // Differing computed values can't be reconciled; collapse to Top.
+            self.inner = PcodeAddressLattice::Top;
+            self.computed = None;
+        } else {
+            self.inner.join(&other.inner);
+        }
     }
 }
 
@@ -230,8 +247,11 @@ impl BasicLocationState {
                 if let Some(addr) = value.as_const_value() {
                     self.inner =
                         PcodeAddressLattice::Const(ConcretePcodeAddress::from(addr as u64));
+                    self.computed = None;
                 } else {
-                    self.inner = PcodeAddressLattice::Computed(value.clone());
+                    // Leave inner as Indirect(ivn) for lattice ordering; store the
+                    // resolved symbolic expression separately.
+                    self.computed = Some(value.clone());
                 }
             }
             // No info → leave as Indirect (two paths with no valuation are genuinely equal)
@@ -245,18 +265,18 @@ impl CfgState for BasicLocationState {
     fn new_const(&self, i: &jingle_sleigh::SleighArchInfo) -> Self::Model {
         match &self.inner {
             PcodeAddressLattice::Const(addr) => MachineState::fresh_for_address(i, *addr),
-            PcodeAddressLattice::Indirect(_)
-            | PcodeAddressLattice::Computed(_)
-            | PcodeAddressLattice::Top => MachineState::fresh(i),
+            PcodeAddressLattice::Indirect(_) | PcodeAddressLattice::Top => MachineState::fresh(i),
         }
     }
 
     fn model_id(&self) -> String {
+        if self.computed.is_some() {
+            return "State_Computed_".to_string();
+        }
         match &self.inner {
             PcodeAddressLattice::Const(a) => a.model_id(),
             PcodeAddressLattice::Top => "State_Top_".to_string(),
             PcodeAddressLattice::Indirect(_) => "State_Indirect_".to_string(),
-            PcodeAddressLattice::Computed(_) => "State_Computed_".to_string(),
         }
     }
 }


### PR DESCRIPTION
At some point I put Value in the lattice, but it really shouldn't be there since that makes every analysis dependent on the value analysis, which goes against the whole point of separating component analyses.