### PR TITLE
feat: add several easy apis

### DIFF
--- a/jingle_sleigh/src/context/mod.rs
+++ b/jingle_sleigh/src/context/mod.rs
@@ -461,6 +461,37 @@ impl SleighContext {
             .map_err(|_| ImageLoadError)
     }
 
+    /// Toggle whether subsequent `setContext()` calls made during disassembly are honored.
+    pub fn allow_context_set(&self, val: bool) {
+        self.ctx.lock().unwrap().allow_context_set(val);
+    }
+
+    /// Register a new context-variable field, in addition to those declared in the `.sla` file.
+    pub fn register_context(&self, name: &str, sbit: i32, ebit: i32) {
+        self.ctx
+            .lock()
+            .unwrap()
+            .pin_mut()
+            .register_context(name, sbit, ebit);
+    }
+
+    /// Look up the register name that exactly matches the given [`VarNode`], requiring an exact
+    /// offset and size match rather than the best-effort match used by
+    /// [`SleighArchInfo::register_name`](crate::space::SleighArchInfo::register_name).
+    pub fn get_exact_register_name(&self, vn: &VarNode) -> Option<String> {
+        let name = self.ctx.lock().unwrap().get_exact_register_name(
+            vn.space_index() as i32,
+            vn.offset(),
+            vn.size() as u32,
+        );
+        if name.is_empty() { None } else { Some(name) }
+    }
+
+    /// Returns `true` if this context has finished parsing its `.sla` definitions.
+    pub fn is_initialized(&self) -> bool {
+        self.ctx.lock().unwrap().is_initialized()
+    }
+
     pub fn spaces(&self) -> Vec<SharedPtr<AddrSpaceHandle>> {
         let ctx = self.ctx.lock().unwrap();
         let mut spaces = Vec::with_capacity(ctx.getNumSpaces() as usize);
@@ -551,6 +582,49 @@ mod test {
     use crate::context::SleighContextBuilder;
     use crate::tests::SLEIGH_ARCH;
     use crate::{OpCode, VarNode};
+
+    #[test]
+    fn allow_context_set_toggles_without_panic() {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        sleigh.allow_context_set(false);
+        sleigh.allow_context_set(true);
+    }
+
+    #[test]
+    fn is_initialized_after_build() {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        assert!(sleigh.is_initialized());
+    }
+
+    #[test]
+    fn register_context_new_field() {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        sleigh.register_context("jingle_test_field", 0, 0);
+    }
+
+    #[test]
+    fn get_exact_register_name_matches() {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        let (vn, name) = sleigh.arch_info().registers().next().unwrap();
+        assert_eq!(sleigh.get_exact_register_name(&vn), Some(name));
+    }
+
+    #[test]
+    fn get_exact_register_name_no_match() {
+        let ctx_builder =
+            SleighContextBuilder::load_ghidra_installation("/Applications/ghidra").unwrap();
+        let sleigh = ctx_builder.build(SLEIGH_ARCH).unwrap();
+        let bogus = VarNode::new(0xdead_beefu64, 3u32, 4u32);
+        assert_eq!(sleigh.get_exact_register_name(&bogus), None);
+    }
 
     #[test]
     fn get_regs() {

--- a/jingle_sleigh/src/ffi/context_ffi.rs
+++ b/jingle_sleigh/src/ffi/context_ffi.rs
@@ -35,6 +35,20 @@ pub(crate) mod bridge {
             value: u32,
         ) -> Result<()>;
 
+        pub(crate) fn allow_context_set(&self, val: bool);
+
+        pub(crate) fn register_context(
+            self: Pin<&mut ContextFFI>,
+            name: &str,
+            sbit: i32,
+            ebit: i32,
+        );
+
+        pub(crate) fn get_exact_register_name(&self, space_idx: i32, off: u64, size: u32)
+        -> String;
+
+        pub(crate) fn is_initialized(&self) -> bool;
+
         pub(crate) fn get_one_instruction(&self, offset: u64) -> Result<InstructionFFI>;
 
         pub(crate) fn getSpaceByIndex(&self, idx: i32) -> SharedPtr<AddrSpaceHandle>;

--- a/jingle_sleigh/src/ffi/cpp/context.cpp
+++ b/jingle_sleigh/src/ffi/cpp/context.cpp
@@ -34,6 +34,23 @@ void ContextFFI::set_initial_context(rust::Str name, uint32_t val) {
   sleigh.setContextDefault(name.operator std::string(), val);
 }
 
+void ContextFFI::allow_context_set(bool val) const {
+  sleigh.allowContextSet(val);
+}
+
+void ContextFFI::register_context(rust::Str name, int32_t sbit, int32_t ebit) {
+  sleigh.registerContext(name.operator std::string(), sbit, ebit);
+}
+
+rust::String ContextFFI::get_exact_register_name(int32_t space_idx, uint64_t off, uint32_t size) const {
+  ghidra::AddrSpace *space = sleigh.getSpace(space_idx);
+  return rust::String(sleigh.getExactRegisterName(space, off, size));
+}
+
+bool ContextFFI::is_initialized() const {
+  return sleigh.isInitialized();
+}
+
 std::shared_ptr<AddrSpaceHandle>
 ContextFFI::getSpaceByIndex(ghidra::int4 idx) const {
   return std::make_shared<AddrSpaceHandle>(sleigh.getSpace(idx));

--- a/jingle_sleigh/src/ffi/cpp/context.h
+++ b/jingle_sleigh/src/ffi/cpp/context.h
@@ -22,6 +22,14 @@ public:
 
     void set_initial_context(rust::Str name, uint32_t val);
 
+    void allow_context_set(bool val) const;
+
+    void register_context(rust::Str name, int32_t sbit, int32_t ebit);
+
+    rust::String get_exact_register_name(int32_t space_idx, uint64_t off, uint32_t size) const;
+
+    bool is_initialized() const;
+
     void setImage(ImageFFI const&img);
 
     InstructionFFI get_one_instruction(uint64_t offset) const;


### PR DESCRIPTION
  Added four APIs to SleighContext (also available on LoadedSleighContext via Deref):
  - `allow_context_set(bool)`: toggles whether `setContext()` calls during disassembly are honored
  - `register_context(name, sbit, ebit)`: registers a new context-variable field at runtime
  - `get_exact_register_name(&VarNode) -> Option<String>`: exact-match register lookup (vs. `arch_info().register_name()`'s best-effort match)
  - `is_initialized() -> bool`: whether the .sla finished parsing